### PR TITLE
53 remove direct GitHub dependency on torchpfaffian to fix pypi publishing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,9 @@ name: Tests
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
 
 permissions:
   contents: read

--- a/poetry.lock
+++ b/poetry.lock
@@ -2328,26 +2328,22 @@ dynamo = ["jinja2"]
 opt-einsum = ["opt-einsum (>=3.3)"]
 
 [[package]]
-name = "TorchPfaffian"
+name = "torchpfaffian"
 version = "0.0.0"
 description = ""
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "python_version <= \"3.11\" or python_version >= \"3.12\""
-files = []
-develop = false
+files = [
+    {file = "torchpfaffian-0.0.0-py3-none-any.whl", hash = "sha256:ce175651fc636796219bd22f248f6b04f94cb2d8b729f31c4fd3323d53184b12"},
+    {file = "torchpfaffian-0.0.0.tar.gz", hash = "sha256:afe290cb14623567e5734f9a42268f2ef4a31747f3f1e6982b4a9dff82baff5d"},
+]
 
 [package.dependencies]
 numpy = ">=1.23.0"
 setuptools = ">=57.0.0"
 torch = "*"
-
-[package.source]
-type = "git"
-url = "https://github.com/MatchCake/TorchPfaffian.git"
-reference = "HEAD"
-resolved_reference = "ef82ebcfea7e59e4f757ef4fba08bd0359b36abb"
 
 [[package]]
 name = "tqdm"
@@ -2446,4 +2442,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "8b57cb19c3e13512a15b8a787fa1a3070967966c042d5513cb9323e0903ffb61"
+content-hash = "bc2f10960fbcd3f41266b8e721605a8dd2a5233a14f98be7112df1e42556e2ff"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,10 +62,10 @@ dependencies = [
     "torch (>=2.1.2,<2.2.0)",
     "tables (>=3.9.2)",
     "pylint (>=3.1.0,<3.2.0)",
-    "torchpfaffian @ git+https://github.com/MatchCake/TorchPfaffian.git",
     "pennylane (==0.39.0)",
     "pandas (>=2.1.0)",
     "pennylane-lightning (==0.39.0)",
+    "torchpfaffian (>=0.0.0)",
 ]
 license={file="LICENSE"}
 


### PR DESCRIPTION
Update the dependency on `torchpfaffian`.