### PR TITLE
Update cicd

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Gather new package version
       id: version
-      uses: anothrNick/github-tag-action@2.12.0
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
@@ -68,7 +68,7 @@ jobs:
 
     - name: Create Tag and Release
       id: create_tag_and_release
-      uses: anothrNick/github-tag-action@2.12.0
+      uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,9 +5,9 @@ name: Tests
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "*" ]
+    branches: ["*"]
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows, specifically addressing version adjustments for an action and branch configurations for testing.

Changes to `.github/workflows/build_dist.yml`:

* Downgraded the `anothrNick/github-tag-action` from version `2.12.0` to `1.61.0` in both the "Gather new package version" and "Create Tag and Release" steps. [[1]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L33-R33) [[2]](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L71-R71)

Changes to `.github/workflows/tests.yml`:

* Updated the branch configuration for the `push` event, removing the `dev` branch and keeping only the `main` branch.