### PR TITLE
Dev

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -44,8 +44,14 @@ jobs:
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
         git add pyproject.toml
-        git diff-index --quiet HEAD || git commit -m "Updating version of pyproject.toml [skip actions]"
-        git push
+        git commit -m "Updating version of pyproject.toml"
+
+    - name: Push the new pyproject.toml
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{secrets.GITHUB_TOKEN}}
+        branch: main
+        force: true
 
     - name: Build dist
       run: |


### PR DESCRIPTION
This pull request updates the workflow for pushing changes to `pyproject.toml` in the `build_dist.yml` GitHub Actions file. The most important change is the replacement of a manual `git push` command with the `ad-m/github-push-action` for improved maintainability and functionality.

### Workflow changes:
* [`.github/workflows/build_dist.yml`](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L47-R54): Replaced the manual `git push` command with the `ad-m/github-push-action` to handle pushing changes to the `main` branch. This includes using the `${{secrets.GITHUB_TOKEN}}` for authentication and enabling the `force` option.