### PR TITLE
Update build_dist.yml

### DIFF
--- a/.github/workflows/build_dist.yml
+++ b/.github/workflows/build_dist.yml
@@ -73,11 +73,17 @@ jobs:
         force: true
         directory: dist
 
-    - name: Create Tag and Release
-      id: create_tag_and_release
+    - name: Create Tag
+      id: tag
       uses: anothrNick/github-tag-action@1.61.0
       env:
         GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         WITH_V: false
         DEFAULT_BUMP: patch
         DRY_RUN: false
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ steps.tag.outputs.new_tag }}
+        generate_release_notes: true


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow to separate the creation of a tag and a release into distinct steps. This change improves clarity and modularity in the workflow.

### Workflow improvements:
* [`.github/workflows/build_dist.yml`](diffhunk://#diff-94abbcc666ebf47df3c54baf467943a0798e35895350bbee769268b4b69f6495L76-R89): Split the "Create Tag and Release" step into two separate steps: "Create Tag" (using `anothrNick/github-tag-action@1.61.0`) and "Create Release" (using `softprops/action-gh-release@v1`). The "Create Release" step now generates release notes automatically.