### PR TITLE
Relax setuptools version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "numpy (>=1.23,<3.0.0)",
-    "setuptools (>=65.5.1,<65.6.0)",
+    "setuptools (>=65.5.1)",
     "scipy (>=1.11.4,<=2)",
     "matplotlib (>=3.8.0)",
     "networkx (>=3.1,<4.0)",

--- a/uv.lock
+++ b/uv.lock
@@ -1168,7 +1168,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.3.2" },
     { name = "scipy", specifier = ">=1.11.4,<=2" },
     { name = "seaborn", specifier = ">=0.13.0" },
-    { name = "setuptools", specifier = ">=65.5.1,<65.6.0" },
+    { name = "setuptools", specifier = ">=65.5.1" },
     { name = "sympy", specifier = ">=1.12,<2.0" },
     { name = "tables", specifier = ">=3.9.1" },
     { name = "torch", specifier = ">=2.1.2,<3.0.0" },


### PR DESCRIPTION
# Description

Updated the setuptools dependency to require only a minimum version (>=65.5.1) instead of restricting the upper bound. This allows compatibility with newer setuptools releases.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `mypy src tests`.
