### PR TITLE
Add autoray dependency to project

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
     "opt-einsum (>=3.4.0)",
     "importlib-metadata (>=8.7.0,<9.0.0)",
     "stim>=1.15.0",
+    "autoray<=0.7.2",
 ]
 dynamic = ["readme"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1174,6 +1174,7 @@ name = "matchcake"
 version = "0.1.2"
 source = { editable = "." }
 dependencies = [
+    { name = "autoray" },
     { name = "importlib-metadata" },
     { name = "matplotlib" },
     { name = "networkx" },
@@ -1253,6 +1254,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "autoray", specifier = "<=0.7.2" },
     { name = "importlib-metadata", specifier = ">=8.7.0,<9.0.0" },
     { name = "matplotlib", specifier = ">=3.8.0" },
     { name = "networkx", specifier = ">=3.1,<4.0" },


### PR DESCRIPTION
# Description

This pull request makes a minor update to the `pyproject.toml` dependencies list by adding a version constraint for the `autoray` package.

* Added `autoray<=0.7.2` to the `dependencies` array in `pyproject.toml` to restrict the maximum version used.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `mypy src tests`.
