### PR TITLE
Fix expectation values of long range diagonal terms.

### DIFF
--- a/src/matchcake/devices/expval_strategies/expval_from_probabilities.py
+++ b/src/matchcake/devices/expval_strategies/expval_from_probabilities.py
@@ -3,6 +3,7 @@ from typing import Union
 import pennylane as qml
 import torch
 from pennylane.operation import Operator, StatePrepBase, TermsUndefinedError
+from pennylane.ops.op_math import Prod
 from pennylane.ops.qubit import Projector
 from pennylane.pauli import pauli_sentence, pauli_word_to_string
 
@@ -18,13 +19,25 @@ class ExpvalFromProbabilitiesStrategy(ExpvalStrategy):
     def __call__(self, state_prep_op: StatePrepBase, observable: Operator, **kwargs) -> TensorLike:
         if not self.can_execute(state_prep_op, observable):
             raise ValueError(f"Cannot execute {self.NAME} strategy for {observable}.")  # pragma: no cover
-        assert "prob" in kwargs, "The probabilities 'prob' must be provided as a keyword argument."
-        prob = kwargs["prob"]
+        hamiltonian = self._format_observable(observable)
+        probs = self.gather_probs(hamiltonian, **kwargs)
         if isinstance(observable, BatchHamiltonian):
             eigvals_on_z_basis = observable.eigvals_on_z_basis()
-            return qml.math.einsum("k,...ki,...ki->...k", observable.coeffs, prob, eigvals_on_z_basis)
-        eigvals_on_z_basis = get_eigvals_on_z_basis(observable)
-        return qml.math.einsum("...i,...i->...", prob, eigvals_on_z_basis)
+            return qml.math.einsum("k,...ki,...ki->...k", observable.coeffs, probs, eigvals_on_z_basis)
+        eigvals_on_z_basis = qml.math.stack([get_eigvals_on_z_basis(t) for c, t in zip(*hamiltonian.terms())])
+        return qml.math.einsum("k,...ki,ki->...", hamiltonian.coeffs, probs, eigvals_on_z_basis)
+
+    def gather_probs(self, hamiltonian, **kwargs) -> TensorLike:
+        assert any(
+            [s in kwargs for s in ["prob", "prob_func"]]
+        ), "Either 'prob' or 'prob_func' must be provided as a keyword argument."
+        if "prob" in kwargs:
+            return kwargs["prob"]
+        assert "prob_func" in kwargs, "The probability function 'prob_func' must be provided as a keyword argument."
+        assert callable(kwargs["prob_func"]), "The 'prob_func' keyword argument must be a callable function."
+        prob_func = kwargs["prob_func"]
+        probs = prob_func([t.wires for c, t in zip(*hamiltonian.terms())])
+        return probs
 
     def can_execute(
         self,
@@ -35,3 +48,16 @@ class ExpvalFromProbabilitiesStrategy(ExpvalStrategy):
             return False
         pauli_kinds = [pauli_word_to_string(op) for op in pauli_sentence(observable)]
         return all((len(set(p) - {"Z", "I"}) == 0) for p in pauli_kinds)
+
+    @staticmethod
+    def _format_observable(observable):
+        if isinstance(observable, BatchHamiltonian):
+            return observable
+        if isinstance(observable, Prod):
+            return qml.Hamiltonian([1.0], [observable])
+        try:
+            terms = observable.terms()
+        except TermsUndefinedError:
+            terms = torch.ones((1,)), [observable]
+        hamiltonian = qml.Hamiltonian(*terms)
+        return hamiltonian

--- a/src/matchcake/devices/expval_strategies/terms_splitter.py
+++ b/src/matchcake/devices/expval_strategies/terms_splitter.py
@@ -28,7 +28,7 @@ class TermsSplitter(ExpvalStrategy):
             raise ValueError(f"Cannot execute {self.NAME} strategy for {observable}.")
         splits = self.split(state_prep_op, observable)
         out = sum(
-            sum(op.scalar * strategy(state_prep_op, op, **self._fix_kwargs_prob(op, **kwargs)) for op in split)
+            sum(op.scalar * strategy(state_prep_op, op, **kwargs) for op in split)
             for split, strategy in zip(splits, self.strategies)
         )
         return out
@@ -52,12 +52,6 @@ class TermsSplitter(ExpvalStrategy):
     ) -> bool:
         hamiltonian = self._format_observable(observable)
         return all(any(s.can_execute(state_prep_op, op) for s in self.strategies) for op in hamiltonian.ops)
-
-    def _fix_kwargs_prob(self, op: SProd, **kwargs):
-        new_kwargs = {**kwargs}
-        if "prob_func" in new_kwargs:
-            new_kwargs["prob"] = new_kwargs["prob_func"](op.wires)
-        return new_kwargs
 
     @staticmethod
     def _format_observable(observable):

--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -703,8 +703,7 @@ class NonInteractingFermionicDevice(qml.devices.QubitDevice):
         if self.clifford_expval_strategy.can_execute(self.state_prep_op, observable):
             return self.clifford_expval_strategy(self.state_prep_op, observable, global_sptm=self.global_sptm.matrix())
         if self.expval_from_probabilities_strategy.can_execute(self.state_prep_op, observable):
-            prob = self.probability(wires=observable.wires)
-            return self.expval_from_probabilities_strategy(self.state_prep_op, observable, prob=prob)
+            return self.expval_from_probabilities_strategy(self.state_prep_op, observable, prob_func=self.probability)
         terms_splitter = TermsSplitter([self.clifford_expval_strategy, self.expval_from_probabilities_strategy])
         if terms_splitter.can_execute(self.state_prep_op, observable):
             return terms_splitter(


### PR DESCRIPTION
# Description

This pull request fix the problem where the computation of expectation values of long range termes trigger the instantiation of exponential size probability vectors.

This pull request also refactors the expectation value computation strategies to support both direct probability arrays and callable probability functions, improving flexibility and modularity. It also removes now-unnecessary helper methods and updates tests to reflect the new interface. Additionally, a new test is added for long-range Hamiltonians.

**Refactoring and interface improvements:**

* `ExpvalFromProbabilitiesStrategy` now accepts either a `prob` array or a `prob_func` callable, with logic to handle both, increasing flexibility for how probabilities are supplied.
* Introduced a new `_format_observable` static method in `ExpvalFromProbabilitiesStrategy` to robustly convert observables to a Hamiltonian form, handling `BatchHamiltonian`, `Prod`, and generic operators.
* The `TermsSplitter` strategy no longer mutates keyword arguments to insert probabilities, as the new interface handles this more cleanly. [[1]](diffhunk://#diff-bee3bd6e051710572670cf0ddb1bf1f120c529a7d6511e9cc649417e8ab0d15dL31-R31) [[2]](diffhunk://#diff-bee3bd6e051710572670cf0ddb1bf1f120c529a7d6511e9cc649417e8ab0d15dL56-L61)

**Device integration:**

* The `NIFDevice.exact_expval` method now passes the probability function (`prob_func`) rather than a precomputed array, leveraging the new interface.

**Testing improvements:**

* Tests for `ExpvalFromProbabilitiesStrategy` are updated to use the `prob_func` interface instead of passing explicit probability arrays. [[1]](diffhunk://#diff-dfc7a5b0fad7b5fb4c9f7c4cc00db131157cf78a7a4d3fcbfce4d3460393594cL64-R66) [[2]](diffhunk://#diff-dfc7a5b0fad7b5fb4c9f7c4cc00db131157cf78a7a4d3fcbfce4d3460393594cL131-R131)
* Added a new test to verify correct behavior for long-range Hamiltonians, increasing test coverage for more complex cases.

**Dependency update:**

* Added import of `Prod` from `pennylane.ops.op_math` to support the new observable formatting logic.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `mypy src tests`.
