### PR TITLE
Add tests for `MAngleEmbedding` and `MAngleEmbeddings` operations

### DIFF
--- a/tests/test_operations/test_angle_embedding.py
+++ b/tests/test_operations/test_angle_embedding.py
@@ -3,7 +3,7 @@ import pennylane as qml
 import pytest
 
 from matchcake import utils
-from matchcake.operations import MAngleEmbedding
+from matchcake.operations import MAngleEmbedding, MAngleEmbeddings
 
 from ..configs import (
     ATOL_APPROX_COMPARISON,
@@ -15,47 +15,135 @@ from ..configs import (
 from ..test_devices import devices_init
 from . import specific_ops_circuit
 
-set_seed(TEST_SEED)
 
+class TestMAngleEmbedding:
+    @pytest.mark.parametrize(
+        "initial_binary_string, rot, is_adjoint, seed",
+        [
+            (i_b_string, rot, adjoint, seed)
+            for rot in ["X", "Y", "Z", "X,Y", "X,Z", "Y,Z", "X,Y,Z"]
+            for i_b_string in ["00", "01", "10", "11"]
+            for adjoint in [True, False]
+            for seed in range(10)
+        ],
+    )
+    def test_m_angle_embedding_with_pennylane_rn_params(
+        self,
+        initial_binary_string,
+        rot,
+        is_adjoint,
+        seed,
+    ):
+        rn_state = np.random.RandomState(seed=seed)
+        rn_params = rn_state.uniform(0.0, np.pi / 2, size=(2,))
+        cls_params_wires_list = [(MAngleEmbedding, rn_params, [0, 1], {"rotations": rot})]
+        initial_binary_state = utils.binary_string_to_vector(initial_binary_string)
+        nif_device, qubit_device = devices_init(wires=len(initial_binary_state))
 
-@pytest.mark.parametrize(
-    "initial_binary_string, cls_params_wires_list, is_adjoint",
-    [
-        (
-            i_b_string,
-            [(MAngleEmbedding, rn_params, [0, 1], {"rotations": rot})],
-            adjoint,
+        nif_qnode = qml.QNode(specific_ops_circuit, nif_device)
+        qubit_qnode = qml.QNode(specific_ops_circuit, qubit_device)
+
+        qubit_expval = qubit_qnode(
+            cls_params_wires_list,
+            initial_binary_state,
+            all_wires=qubit_device.wires,
+            out_op="expval",
+            adjoint=is_adjoint,
         )
-        for rot in ["X", "Y", "Z", "X,Y", "X,Z", "Y,Z", "X,Y,Z"]
-        for i_b_string in ["00", "01", "10", "11"]
-        for rn_params in np.random.uniform(0.0, np.pi / 2, size=(N_RANDOM_TESTS_PER_CASE, 2))
-        for adjoint in [True, False]
-    ],
-)
-def test_m_angle_embedding_with_pennylane(initial_binary_string, cls_params_wires_list, is_adjoint):
-    initial_binary_state = utils.binary_string_to_vector(initial_binary_string)
-    nif_device, qubit_device = devices_init(wires=len(initial_binary_state))
+        nif_expval = nif_qnode(
+            cls_params_wires_list,
+            initial_binary_state,
+            all_wires=nif_device.wires,
+            out_op="expval",
+            adjoint=is_adjoint,
+        )
+        np.testing.assert_allclose(
+            nif_expval,
+            qubit_expval,
+            atol=ATOL_APPROX_COMPARISON,
+            rtol=RTOL_APPROX_COMPARISON,
+        )
 
-    nif_qnode = qml.QNode(specific_ops_circuit, nif_device)
-    qubit_qnode = qml.QNode(specific_ops_circuit, qubit_device)
+    def test_repr(self):
+        op = MAngleEmbedding(np.asarray([0.1, 0.2]), [0, 1])
+        op_repr = repr(op)
+        assert isinstance(op_repr, str)
+        assert "MAngleEmbedding" in op_repr
 
-    qubit_expval = qubit_qnode(
-        cls_params_wires_list,
-        initial_binary_state,
-        all_wires=qubit_device.wires,
-        out_op="expval",
-        adjoint=is_adjoint,
+    def test_ndim_params_property(self):
+        op = MAngleEmbedding(np.asarray([0.1, 0.2]), [0, 1])
+        assert op.ndim_params == (1,)
+
+    def test_init_with_wrong_params(self):
+        with pytest.raises(ValueError):
+            MAngleEmbedding(np.asarray([0.1, 0.2, 0.3]), [0, 1])
+
+    def test_init_with_padding(self):
+        op = MAngleEmbedding(
+            np.asarray(
+                [
+                    0.1,
+                ]
+            ),
+            [0, 1],
+        )
+        assert qml.math.shape(op.parameters) == (1, 2)
+
+
+class TestMAngleEmbeddings:
+    @pytest.mark.parametrize(
+        "initial_binary_string, rot, is_adjoint, seed",
+        [
+            (i_b_string, rot, adjoint, seed)
+            for rot in ["X", "Y", "Z", "X,Y", "X,Z", "Y,Z", "X,Y,Z"]
+            for i_b_string in ["00", "01", "10", "11"]
+            for adjoint in [True, False]
+            for seed in range(10)
+        ],
     )
-    nif_expval = nif_qnode(
-        cls_params_wires_list,
-        initial_binary_state,
-        all_wires=nif_device.wires,
-        out_op="expval",
-        adjoint=is_adjoint,
-    )
-    np.testing.assert_allclose(
-        nif_expval,
-        qubit_expval,
-        atol=ATOL_APPROX_COMPARISON,
-        rtol=RTOL_APPROX_COMPARISON,
-    )
+    def test_against_pennylane_rn_params(
+        self,
+        initial_binary_string,
+        rot,
+        is_adjoint,
+        seed,
+    ):
+        rn_state = np.random.RandomState(seed=seed)
+        rn_params = rn_state.uniform(0.0, np.pi / 2, size=(2,))
+        cls_params_wires_list = [(MAngleEmbeddings, rn_params, [0, 1], {"rotations": rot})]
+        initial_binary_state = utils.binary_string_to_vector(initial_binary_string)
+        nif_device, qubit_device = devices_init(wires=len(initial_binary_state))
+
+        nif_qnode = qml.QNode(specific_ops_circuit, nif_device)
+        qubit_qnode = qml.QNode(specific_ops_circuit, qubit_device)
+
+        qubit_expval = qubit_qnode(
+            cls_params_wires_list,
+            initial_binary_state,
+            all_wires=qubit_device.wires,
+            out_op="expval",
+            adjoint=is_adjoint,
+        )
+        nif_expval = nif_qnode(
+            cls_params_wires_list,
+            initial_binary_state,
+            all_wires=nif_device.wires,
+            out_op="expval",
+            adjoint=is_adjoint,
+        )
+        np.testing.assert_allclose(
+            nif_expval,
+            qubit_expval,
+            atol=ATOL_APPROX_COMPARISON,
+            rtol=RTOL_APPROX_COMPARISON,
+        )
+
+    def test_repr(self):
+        op = MAngleEmbeddings(np.asarray([0.1, 0.2]), [0, 1])
+        op_repr = repr(op)
+        assert isinstance(op_repr, str)
+        assert "MAngleEmbeddings" in op_repr
+
+    def test_ndim_params_property(self):
+        op = MAngleEmbeddings(np.asarray([0.1, 0.2]), [0, 1])
+        assert op.ndim_params == (1,)


### PR DESCRIPTION
# Description

This pull request introduces significant improvements to the `Matchgate AngleEmbedding` operations, including enhanced documentation and expanded test coverage. The changes clarify the distinction between `MAngleEmbedding` and `MAngleEmbeddings`, provide detailed docstrings for both classes, and add comprehensive tests for their functionality and edge cases.

Enhancements to operation documentation:

* Added a detailed docstring to the `MAngleEmbedding` class, explaining its purpose, feature padding behavior, and customizable rotations.
* Added an extensive docstring to the `MAngleEmbeddings` class, highlighting its multi-layer embedding capability, wire-pair cycling, and differences from `MAngleEmbedding`.

Test suite improvements:

* Introduced a new `TestMAngleEmbedding` class with parameterized tests for rotation types, initial states, adjoint operations, and random seeds, as well as tests for representation, parameter dimension, error handling, and feature padding.
* Added a `TestMAngleEmbeddings` class with similar parameterized tests and additional coverage for representation and parameter dimension properties.

Code cleanup:

* Removed unused imports (`warnings`, `defaultdict`, `partial`) from `src/matchcake/operations/angle_embedding.py` for better code hygiene.
* Updated test imports to include both `MAngleEmbedding` and `MAngleEmbeddings`.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `uv run black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `uv run isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
