### PR TITLE
Add alignment hyperparameters to NIF kernels

### DIFF
--- a/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
+++ b/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
@@ -74,6 +74,7 @@ class FermionicPQCKernel(NIFKernel):
         initialized during the `fit` method call.
     :type data_scaling_: torch.nn.parameter.Parameter
     """
+
     DEFAULT_ROTATIONS = "Y,Z"
     DEFAULT_ENTANGLING_MTH = "fswap"
     available_entangling_mth = {"fswap", "identity", "hadamard"}
@@ -81,16 +82,16 @@ class FermionicPQCKernel(NIFKernel):
     def __init__(
         self,
         *,
-        gram_batch_size: int = FermionicPQCKernel.DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = FermionicPQCKernel.DEFAULT_RANDOM_STATE,
-        alignment: bool = FermionicPQCKernel.DEFAULT_ALIGNMENT,
-        alignment_iterations: int = FermionicPQCKernel.DEFAULT_ALIGNMENT_ITERATIONS,
-        alignment_learning_rate: float = FermionicPQCKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
-        alignment_early_stopping_patience: int = FermionicPQCKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
-        alignment_early_stopping_threshold: float = FermionicPQCKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
-        n_qubits: int = FermionicPQCKernel.DEFAULT_N_QUBITS,
-        rotations: str = FermionicPQCKernel.DEFAULT_ROTATIONS,
-        entangling_mth: str = FermionicPQCKernel.DEFAULT_ENTANGLING_MTH,
+        gram_batch_size: int = NIFKernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = NIFKernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = NIFKernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = NIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = NIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
+        rotations: str = DEFAULT_ROTATIONS,
+        entangling_mth: str = DEFAULT_ENTANGLING_MTH,
     ):
         """
         Initializes the class with specified parameters for quantum circuit design and

--- a/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
+++ b/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
@@ -74,24 +74,23 @@ class FermionicPQCKernel(NIFKernel):
         initialized during the `fit` method call.
     :type data_scaling_: torch.nn.parameter.Parameter
     """
-
-    DEFAULT_N_QUBITS = 12
-    DEFAULT_GRAM_BATCH_SIZE = 10_000
+    DEFAULT_ROTATIONS = "Y,Z"
+    DEFAULT_ENTANGLING_MTH = "fswap"
     available_entangling_mth = {"fswap", "identity", "hadamard"}
 
     def __init__(
         self,
         *,
-        gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = 0,
-        alignment: bool = False,
-        alignment_iterations: int = 100,
-        alignment_learning_rate: float = 1e-3,
-        alignment_early_stopping_patience: int = 10,
-        alignment_early_stopping_threshold: float = 1e-5,
-        n_qubits: int = DEFAULT_N_QUBITS,
-        rotations: str = "Y,Z",
-        entangling_mth: str = "fswap",
+        gram_batch_size: int = FermionicPQCKernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = FermionicPQCKernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = FermionicPQCKernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = FermionicPQCKernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = FermionicPQCKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = FermionicPQCKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = FermionicPQCKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = FermionicPQCKernel.DEFAULT_N_QUBITS,
+        rotations: str = FermionicPQCKernel.DEFAULT_ROTATIONS,
+        entangling_mth: str = FermionicPQCKernel.DEFAULT_ENTANGLING_MTH,
     ):
         """
         Initializes the class with specified parameters for quantum circuit design and

--- a/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
+++ b/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
@@ -85,6 +85,10 @@ class FermionicPQCKernel(NIFKernel):
         gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
         random_state: int = 0,
         alignment: bool = False,
+        alignment_iterations: int = 100,
+        alignment_learning_rate: float = 1e-3,
+        alignment_early_stopping_patience: int = 10,
+        alignment_early_stopping_threshold: float = 1e-5,
         n_qubits: int = DEFAULT_N_QUBITS,
         rotations: str = "Y,Z",
         entangling_mth: str = "fswap",
@@ -96,6 +100,11 @@ class FermionicPQCKernel(NIFKernel):
 
         :param gram_batch_size: Size of the gram batch, used for processing data in batches.
         :param random_state: Seed for random number generator to ensure reproducibility.
+        :param alignment: A boolean flag indicating whether to perform kernel alignment during fitting.
+        :param alignment_iterations: The maximum number of iterations for kernel alignment optimization.
+        :param alignment_learning_rate: The learning rate for the optimizer used in kernel alignment.
+        :param alignment_early_stopping_patience: The number of iterations to wait for improvement before stopping kernel alignment optimization.
+        :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel alignment optimization, used for early stopping criteria.
         :param n_qubits: Number of qubits to be used in the quantum circuit.
         :param rotations: Types of rotations to be applied in the quantum circuit, specified
             as a comma-separated string (e.g., "Y,Z").
@@ -106,6 +115,10 @@ class FermionicPQCKernel(NIFKernel):
             gram_batch_size=gram_batch_size,
             random_state=random_state,
             alignment=alignment,
+            alignment_iterations=alignment_iterations,
+            alignment_learning_rate=alignment_learning_rate,
+            alignment_early_stopping_patience=alignment_early_stopping_patience,
+            alignment_early_stopping_threshold=alignment_early_stopping_threshold,
             n_qubits=n_qubits,
         )
         self.rotations = rotations

--- a/src/matchcake/ml/kernels/kernel.py
+++ b/src/matchcake/ml/kernels/kernel.py
@@ -46,6 +46,11 @@ class Kernel(torch.nn.Module, TransformerMixin, BaseEstimator):
 
         :param gram_batch_size: The batch size to be used for processing gram matrices.
         :param random_state: The seed value for ensuring reproducible random number generation.
+        :param alignment: A boolean flag indicating whether to perform kernel alignment during fitting.
+        :param alignment_iterations: The maximum number of iterations for kernel alignment optimization.
+        :param alignment_learning_rate: The learning rate for the optimizer used in kernel alignment.
+        :param alignment_early_stopping_patience: The number of iterations to wait for improvement before stopping kernel alignment optimization.
+        :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel alignment optimization, used for early stopping criteria.
         """
         super().__init__()
         self.gram_batch_size = gram_batch_size

--- a/src/matchcake/ml/kernels/kernel.py
+++ b/src/matchcake/ml/kernels/kernel.py
@@ -29,17 +29,23 @@ class Kernel(torch.nn.Module, TransformerMixin, BaseEstimator):
     """
 
     DEFAULT_GRAM_BATCH_SIZE = 10_000
+    DEFAULT_RANDOM_STATE = 0
+    DEFAULT_ALIGNMENT = False
+    DEFAULT_ALIGNMENT_ITERATIONS = 100
+    DEFAULT_ALIGNMENT_LEARNING_RATE = 1e-3
+    DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE = 10
+    DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD = 1e-5
 
     def __init__(
         self,
         *,
         gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = 0,
-        alignment: bool = False,
-        alignment_iterations: int = 100,
-        alignment_learning_rate: float = 1e-3,
-        alignment_early_stopping_patience: int = 10,
-        alignment_early_stopping_threshold: float = 1e-5,
+        random_state: int = DEFAULT_RANDOM_STATE,
+        alignment: bool = DEFAULT_ALIGNMENT,
+        alignment_iterations: int = DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
     ):
         """
         Initializes the class with configurations related to batch sizes and random state.

--- a/src/matchcake/ml/kernels/linear_nif_kernel.py
+++ b/src/matchcake/ml/kernels/linear_nif_kernel.py
@@ -36,6 +36,10 @@ class LinearNIFKernel(NIFKernel):
         gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
         random_state: int = 0,
         alignment: bool = False,
+        alignment_iterations: int = 100,
+        alignment_learning_rate: float = 1e-3,
+        alignment_early_stopping_patience: int = 10,
+        alignment_early_stopping_threshold: float = 1e-5,
         n_qubits: int = DEFAULT_N_QUBITS,
         bias: bool = True,
         encoder_activation: str = "Identity",
@@ -51,6 +55,16 @@ class LinearNIFKernel(NIFKernel):
         :param random_state: Seed value for random number generation to ensure
             reproducibility and consistency.
         :type random_state: int
+        :param alignment: A boolean flag indicating whether to perform kernel alignment during fitting.
+        :type alignment: bool
+        :param alignment_iterations: The maximum number of iterations for kernel alignment optimization.
+        :type alignment_iterations: int
+        :param alignment_learning_rate: The learning rate for the optimizer used in kernel alignment.
+        :type alignment_learning_rate: float
+        :param alignment_early_stopping_patience: The number of iterations to wait for improvement before stopping kernel alignment optimization.
+        :type alignment_early_stopping_patience: int
+        :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel alignment optimization, used for early stopping criteria.
+        :type alignment_early_stopping_threshold: float
         :param n_qubits: Number of qubits used in the quantum computation process.
         :type n_qubits: int
         :param bias: Determines if the linear layers in the encoder should include a
@@ -64,6 +78,10 @@ class LinearNIFKernel(NIFKernel):
             gram_batch_size=gram_batch_size,
             random_state=random_state,
             alignment=alignment,
+            alignment_iterations=alignment_iterations,
+            alignment_learning_rate=alignment_learning_rate,
+            alignment_early_stopping_patience=alignment_early_stopping_patience,
+            alignment_early_stopping_threshold=alignment_early_stopping_threshold,
             n_qubits=n_qubits,
         )
         self._bias = bias

--- a/src/matchcake/ml/kernels/linear_nif_kernel.py
+++ b/src/matchcake/ml/kernels/linear_nif_kernel.py
@@ -33,16 +33,16 @@ class LinearNIFKernel(NIFKernel):
     def __init__(
         self,
         *,
-        gram_batch_size: int = LinearNIFKernel.DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = LinearNIFKernel.DEFAULT_RANDOM_STATE,
-        alignment: bool = LinearNIFKernel.DEFAULT_ALIGNMENT,
-        alignment_iterations: int = LinearNIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
-        alignment_learning_rate: float = LinearNIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
-        alignment_early_stopping_patience: int = LinearNIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
-        alignment_early_stopping_threshold: float = LinearNIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
-        n_qubits: int = LinearNIFKernel.DEFAULT_N_QUBITS,
-        bias: bool = LinearNIFKernel.DEFAULT_BIAS,
-        encoder_activation: str = LinearNIFKernel.DEFAULT_ENCODER_ACTIVATION,
+        gram_batch_size: int = NIFKernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = NIFKernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = NIFKernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = NIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = NIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
+        bias: bool = DEFAULT_BIAS,
+        encoder_activation: str = DEFAULT_ENCODER_ACTIVATION,
     ):
         """
         Initializes the class with configurable parameters for the model's encoder

--- a/src/matchcake/ml/kernels/linear_nif_kernel.py
+++ b/src/matchcake/ml/kernels/linear_nif_kernel.py
@@ -27,22 +27,22 @@ class LinearNIFKernel(NIFKernel):
     :type DEFAULT_GRAM_BATCH_SIZE: int
     """
 
-    DEFAULT_N_QUBITS = 12
-    DEFAULT_GRAM_BATCH_SIZE = 10_000
+    DEFAULT_BIAS = True
+    DEFAULT_ENCODER_ACTIVATION = "Identity"
 
     def __init__(
         self,
         *,
-        gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = 0,
-        alignment: bool = False,
-        alignment_iterations: int = 100,
-        alignment_learning_rate: float = 1e-3,
-        alignment_early_stopping_patience: int = 10,
-        alignment_early_stopping_threshold: float = 1e-5,
-        n_qubits: int = DEFAULT_N_QUBITS,
-        bias: bool = True,
-        encoder_activation: str = "Identity",
+        gram_batch_size: int = LinearNIFKernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = LinearNIFKernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = LinearNIFKernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = LinearNIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = LinearNIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = LinearNIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = LinearNIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = LinearNIFKernel.DEFAULT_N_QUBITS,
+        bias: bool = LinearNIFKernel.DEFAULT_BIAS,
+        encoder_activation: str = LinearNIFKernel.DEFAULT_ENCODER_ACTIVATION,
     ):
         """
         Initializes the class with configurable parameters for the model's encoder

--- a/src/matchcake/ml/kernels/nif_kernel.py
+++ b/src/matchcake/ml/kernels/nif_kernel.py
@@ -28,21 +28,19 @@ class NIFKernel(Kernel):
     :ivar R_DTYPE: Data type used for computation within the kernel.
     :type R_DTYPE: torch.dtype
     """
-
     DEFAULT_N_QUBITS = 12
-    DEFAULT_GRAM_BATCH_SIZE = 10_000
 
     def __init__(
         self,
         *,
-        gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = 0,
-        alignment: bool = False,
-        alignment_iterations: int = 100,
-        alignment_learning_rate: float = 1e-3,
-        alignment_early_stopping_patience: int = 10,
-        alignment_early_stopping_threshold: float = 1e-5,
-        n_qubits: int = DEFAULT_N_QUBITS,
+        gram_batch_size: int = NIFKernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = NIFKernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = NIFKernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = NIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = NIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
     ):
         """
         Initializes the class with specific parameters for quantum device configuration and

--- a/src/matchcake/ml/kernels/nif_kernel.py
+++ b/src/matchcake/ml/kernels/nif_kernel.py
@@ -38,6 +38,10 @@ class NIFKernel(Kernel):
         gram_batch_size: int = DEFAULT_GRAM_BATCH_SIZE,
         random_state: int = 0,
         alignment: bool = False,
+        alignment_iterations: int = 100,
+        alignment_learning_rate: float = 1e-3,
+        alignment_early_stopping_patience: int = 10,
+        alignment_early_stopping_threshold: float = 1e-5,
         n_qubits: int = DEFAULT_N_QUBITS,
     ):
         """
@@ -46,12 +50,21 @@ class NIFKernel(Kernel):
 
         :param gram_batch_size: The batch size for the Gram computation.
         :param random_state: Seed for the random number generator to ensure reproducibility.
+        :param alignment: A boolean flag indicating whether to perform kernel alignment during fitting.
+        :param alignment_iterations: The maximum number of iterations for kernel alignment optimization.
+        :param alignment_learning_rate: The learning rate for the optimizer used in kernel alignment.
+        :param alignment_early_stopping_patience: The number of iterations to wait for improvement before stopping kernel alignment optimization.
+        :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel alignment optimization, used for early stopping criteria.
         :param n_qubits: The number of qubits for the non-interacting fermionic device.
         """
         super().__init__(
             gram_batch_size=gram_batch_size,
             random_state=random_state,
             alignment=alignment,
+            alignment_iterations=alignment_iterations,
+            alignment_learning_rate=alignment_learning_rate,
+            alignment_early_stopping_patience=alignment_early_stopping_patience,
+            alignment_early_stopping_threshold=alignment_early_stopping_threshold,
         )
         self.R_DTYPE = torch.float32
         self._q_device = NonInteractingFermionicDevice(n_qubits, r_dtype=self.R_DTYPE)

--- a/src/matchcake/ml/kernels/nif_kernel.py
+++ b/src/matchcake/ml/kernels/nif_kernel.py
@@ -28,19 +28,20 @@ class NIFKernel(Kernel):
     :ivar R_DTYPE: Data type used for computation within the kernel.
     :type R_DTYPE: torch.dtype
     """
+
     DEFAULT_N_QUBITS = 12
 
     def __init__(
         self,
         *,
-        gram_batch_size: int = NIFKernel.DEFAULT_GRAM_BATCH_SIZE,
-        random_state: int = NIFKernel.DEFAULT_RANDOM_STATE,
-        alignment: bool = NIFKernel.DEFAULT_ALIGNMENT,
-        alignment_iterations: int = NIFKernel.DEFAULT_ALIGNMENT_ITERATIONS,
-        alignment_learning_rate: float = NIFKernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
-        alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
-        alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
-        n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
+        gram_batch_size: int = Kernel.DEFAULT_GRAM_BATCH_SIZE,
+        random_state: int = Kernel.DEFAULT_RANDOM_STATE,
+        alignment: bool = Kernel.DEFAULT_ALIGNMENT,
+        alignment_iterations: int = Kernel.DEFAULT_ALIGNMENT_ITERATIONS,
+        alignment_learning_rate: float = Kernel.DEFAULT_ALIGNMENT_LEARNING_RATE,
+        alignment_early_stopping_patience: int = Kernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
+        alignment_early_stopping_threshold: float = Kernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
+        n_qubits: int = DEFAULT_N_QUBITS,
     ):
         """
         Initializes the class with specific parameters for quantum device configuration and


### PR DESCRIPTION
# Description

Expose alignment training parameters on NIFKernel and its subclasses (LinearNIFKernel, FermionicPQCKernel). Adds constructor arguments for alignment_iterations (default 100), alignment_learning_rate (default 1e-3), alignment_early_stopping_patience (default 10) and alignment_early_stopping_threshold (default 1e-5) and propagates them through the subclass constructors so alignment optimization can be configured externally.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `uv run black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `uv run isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
