### PR TITLE
Cross validation indices support

### DIFF
--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -146,23 +146,21 @@ class CrossValidation:
                 estimator=estimator, X=self.x, y=self.y, cv=self.cv, **self.cross_validate_kwargs
             )
             n_splits = len(cv_result[list(cv_result.keys())[0]])
-            cv_result_list = [
-                {
-                    self.ESTIMATOR_NAME_KEY: estimator_name,
-                    **{
-                        k: (
-                            {
-                                self.INDICES_TRAIN_KEY: v[self.INDICES_TRAIN_KEY][i],
-                                self.INDICES_TEST_KEY: v[self.INDICES_TEST_KEY][i],
-                            }
-                            if k == self.INDICES_NAME_KEY
-                            else v[i]
-                        )
-                        for k, v in cv_result.items()
-                    },
-                }
-                for i in range(n_splits)
-            ]
+
+            def cv_result_destructure(k, v):
+                if k == self.INDICES_NAME_KEY:
+                    return {
+                        self.INDICES_TRAIN_KEY: v[self.INDICES_TRAIN_KEY][i],
+                        self.INDICES_TEST_KEY: v[self.INDICES_TEST_KEY][i],
+                    }
+                return v[i]
+
+            cv_result_list = []
+            for i in range(n_splits):
+                cv_result_dict = {}
+                for k, v in cv_result.items():
+                    cv_result_dict.update({k: cv_result_destructure(k, v)})
+                cv_result_list.append({self.ESTIMATOR_NAME_KEY: estimator_name, **cv_result_dict})
             results.extend(cv_result_list)
         results_df = pd.DataFrame(results)
         cvo = CrossValidationOutput(self.estimators, results_df, estimator_name_key=self.ESTIMATOR_NAME_KEY)

--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -64,7 +64,13 @@ class CrossValidation:
             )
             n_splits = len(cv_result[list(cv_result.keys())[0]])
             cv_result_list = [
-                {self.ESTIMATOR_NAME_KEY: estimator_name, **{k: v[i] for k, v in cv_result.items()}}
+                {
+                    self.ESTIMATOR_NAME_KEY: estimator_name,
+                    **{
+                        k: {"train": v["train"][i], "test": v["test"][i]} if k == "indices" else v[i]
+                        for k, v in cv_result.items()
+                    },
+                }
                 for i in range(n_splits)
             ]
             results.extend(cv_result_list)

--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -9,6 +9,20 @@ from matchcake.typing import TensorLike
 
 
 class CrossValidationOutput:
+    r"""
+    The CrossValidation class defines an object to encapsulate the handling and the outputs of scikit-learn Cross-validation module.
+
+    It can run multiple estimators one after another to test the performance of each of them in a reproducible manner.
+
+    :ivar ESTIMATOR_NAME_KEY: Internal key name for estimator names
+    :type ESTIMATOR_NAME_KEY: str
+    :ivar estimators: The dictionary mapping estimator names to the estimator.
+    :type estimators: dict
+    :ivar results_df: The dataframe containing the results of the cross-validation test.
+    :type results_df: Dataframe
+    :ivar estimator_name_key: The key to the estimator name
+    :type estimator_name_key: str
+    """
     ESTIMATOR_NAME_KEY = "estimator_name"
 
     def __init__(
@@ -18,16 +32,46 @@ class CrossValidationOutput:
         *,
         estimator_name_key: str = ESTIMATOR_NAME_KEY,
     ):
+        """
+        Initialize the CrossValidationOutput.
+
+        :param estimators: The tested estimators
+        :param results_df: The results of the cross-validation
+        :param estimator_name_key: The name to access the estimator name in the Dataframe.        
+        """
         self.estimators = estimators
         self.results_df = results_df
         self.estimator_name_key = estimator_name_key
 
     @property
     def score_columns(self) -> List[str]:
+        """
+        Returns only the columns with score values from the Dataframe.
+
+        :return: A list of columns containing the score values. 
+        """
         return [c for c in self.results_df.columns if c.startswith("test_") or c.startswith("train_")]
 
 
 class CrossValidation:
+    r"""
+    The CrossValidation class defines an object to encapsulate the handling and the outputs of scikit-learn Cross-validation module.
+
+    It can run multiple estimators one after another to test the performance of each of them in a reproducible manner.
+
+    :ivar ESTIMATOR_NAME_KEY: Internal key name for estimator names.
+    :type ESTIMATOR_NAME_KEY: str
+    :ivar estimators: The dictionary mapping estimator names to the estimator.
+    :type estimators: dict
+    :ivar x: The independant variable.
+    :type x: Any tensor-compatible object.
+    :ivar y: The dependant variable.
+    :type y: Any tensor-compatible object.
+    :ivar cv: The Cross-Validation method. If none is passed, it will default to a StratifiedShuffleSplit with 20 splits and a train-test ration of 80-20
+    :type cv: Cross-validator
+    :ivar cross_validator_kwargs: Additional arguments to pass to the cross-validator. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation
+    :type cross_validator_kwargs: dict
+    """
     ESTIMATOR_NAME_KEY = "estimator_name"
 
     def __init__(
@@ -37,8 +81,30 @@ class CrossValidation:
         y: Optional[TensorLike] = None,
         *,
         cv: Optional[Any] = None,
-        cross_validate_kwargs: Optional[Dict[str, Any]] = None,
+        cross_validate_kwargs: Optional[Dict[str, bool]] = None,
     ):
+        """
+        Initialize the Cross-Validator with the estimators to validate and the data to train it on.
+
+        Passed cross-validator kwargs must have the form:
+        ```json
+        {
+            'return_train_score': True,
+            'return_estimator': True,
+            'return_estimator': True,
+        }
+        ```
+        Each kwarg is optional and can be of value True or False. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation for information on these parameters.
+
+        :param estimators: Dictionary mapping estimator names to the estimator
+        :param x: Independant variable to be processed.
+        :param y: Dependant variable to be processed.
+        :type y: Any tensor-compatible object.
+        :param cv: The cross-validator. Will use a StratifiedShuffleSplit with 20 splits by default.
+        :type cv: An initialised cross-validator.
+        :ivar cross_validator_kwargs: Additional arguments to pass to the cross-validator. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation .
+        :type cross_validator_kwargs: A mapping between the arguments and their True/False value.
+        """
         self.estimators = estimators
         self.x = x
         self.y = y
@@ -51,6 +117,12 @@ class CrossValidation:
         self.cross_validate_kwargs.setdefault("return_train_score", True)
 
     def run(self, verbose=True) -> CrossValidationOutput:
+        """
+        Run the cross-validation. It will run all estimators with the same data and cross-validation method. Outputs of the cross-validation will be saved in a CrossValidationOutput object.
+
+        :param verbose: If to show progress.
+        :return: A CrossValidationOutput object.        
+        """
         results = []
         p_bar = tqdm(
             self.estimators.items(),

--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -127,6 +127,25 @@ class CrossValidation:
         self.cross_validate_kwargs = cross_validate_kwargs
         self.cross_validate_kwargs.setdefault("return_train_score", True)
 
+    def _cv_result_destructure(self, cv_result: dict[str, Any], index: int) -> dict[str, Any]:
+        """Destructure the result of the cross-validation
+
+        :param cv_result: The complete results from the Cross-Validation
+        :param index: The current index of the cross-validation iteration in the cv_result data
+        :return: Reformatted dictionary information for the cross-validation iteration
+        """
+        cv_result_dict = {}
+        for k, v in cv_result.items():
+            if k == self.INDICES_NAME_KEY:
+                value = {
+                    self.INDICES_TRAIN_KEY: v[self.INDICES_TRAIN_KEY][index],
+                    self.INDICES_TEST_KEY: v[self.INDICES_TEST_KEY][index],
+                }
+            else:
+                value = v[index]
+            cv_result_dict.update({k: value})
+        return cv_result_dict
+
     def run(self, verbose=True) -> CrossValidationOutput:
         """
         Run the cross-validation. It will run all estimators with the same data and cross-validation method. Outputs of the cross-validation will be saved in a CrossValidationOutput object.
@@ -147,20 +166,11 @@ class CrossValidation:
             )
             n_splits = len(cv_result[list(cv_result.keys())[0]])
 
-            def cv_result_destructure(k, v):
-                if k == self.INDICES_NAME_KEY:
-                    return {
-                        self.INDICES_TRAIN_KEY: v[self.INDICES_TRAIN_KEY][i],
-                        self.INDICES_TEST_KEY: v[self.INDICES_TEST_KEY][i],
-                    }
-                return v[i]
-
             cv_result_list = []
             for i in range(n_splits):
-                cv_result_dict = {}
-                for k, v in cv_result.items():
-                    cv_result_dict.update({k: cv_result_destructure(k, v)})
-                cv_result_list.append({self.ESTIMATOR_NAME_KEY: estimator_name, **cv_result_dict})
+                cv_result_list.append(
+                    {self.ESTIMATOR_NAME_KEY: estimator_name, **self._cv_result_destructure(cv_result, i)}
+                )
             results.extend(cv_result_list)
         results_df = pd.DataFrame(results)
         cvo = CrossValidationOutput(self.estimators, results_df, estimator_name_key=self.ESTIMATOR_NAME_KEY)

--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -92,20 +92,20 @@ class CrossValidation:
         y: Optional[TensorLike] = None,
         *,
         cv: Optional[Any] = None,
-        cross_validate_kwargs: Optional[Dict[str, bool]] = None,
+        cross_validate_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize the Cross-Validator with the estimators to validate and the data to train it on.
 
-        Passed cross-validator kwargs must have the form:
-        ```json
+        Passed cross-validator kwargs can have the form:
+        ```
         {
             'return_train_score': True,
             'return_estimator': True,
             'return_indices': True,
         }
         ```
-        Each kwarg is optional and can be of value True or False. By default, `return_train_score` will be True. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation for information on these parameters.
+        These kwargs are optional. By default, `return_train_score` will be True. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation for information on these parameters.
 
         :param estimators: Dictionary mapping estimator names to the estimator
         :param x: Independant variable to be processed.

--- a/src/matchcake/ml/cross_validation.py
+++ b/src/matchcake/ml/cross_validation.py
@@ -23,6 +23,7 @@ class CrossValidationOutput:
     :ivar estimator_name_key: The key to the estimator name
     :type estimator_name_key: str
     """
+
     ESTIMATOR_NAME_KEY = "estimator_name"
 
     def __init__(
@@ -37,7 +38,7 @@ class CrossValidationOutput:
 
         :param estimators: The tested estimators
         :param results_df: The results of the cross-validation
-        :param estimator_name_key: The name to access the estimator name in the Dataframe.        
+        :param estimator_name_key: The name to access the estimator name in the Dataframe.
         """
         self.estimators = estimators
         self.results_df = results_df
@@ -48,7 +49,7 @@ class CrossValidationOutput:
         """
         Returns only the columns with score values from the Dataframe.
 
-        :return: A list of columns containing the score values. 
+        :return: A list of columns containing the score values.
         """
         return [c for c in self.results_df.columns if c.startswith("test_") or c.startswith("train_")]
 
@@ -61,6 +62,12 @@ class CrossValidation:
 
     :ivar ESTIMATOR_NAME_KEY: Internal key name for estimator names.
     :type ESTIMATOR_NAME_KEY: str
+    :ivar INDICES_NAME_KEY: Internal key name for indices.
+    :type INDICES_NAME_KEY: str
+    :ivar INDICES_TRAIN_KEY: Internal key name for training indices.
+    :type INDICES_TRAIN_KEY: str
+    :ivar INDICES_TEST_KEY: Internal key name for testing indices.
+    :type INDICES_TEST_KEY: str
     :ivar estimators: The dictionary mapping estimator names to the estimator.
     :type estimators: dict
     :ivar x: The independant variable.
@@ -72,7 +79,11 @@ class CrossValidation:
     :ivar cross_validator_kwargs: Additional arguments to pass to the cross-validator. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation
     :type cross_validator_kwargs: dict
     """
+
     ESTIMATOR_NAME_KEY = "estimator_name"
+    INDICES_NAME_KEY = "indices"
+    INDICES_TRAIN_KEY = "train"
+    INDICES_TEST_KEY = "test"
 
     def __init__(
         self,
@@ -91,10 +102,10 @@ class CrossValidation:
         {
             'return_train_score': True,
             'return_estimator': True,
-            'return_estimator': True,
+            'return_indices': True,
         }
         ```
-        Each kwarg is optional and can be of value True or False. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation for information on these parameters.
+        Each kwarg is optional and can be of value True or False. By default, `return_train_score` will be True. See https://scikit-learn.org/stable/modules/cross_validation.html#the-cross-validate-function-and-multiple-metric-evaluation for information on these parameters.
 
         :param estimators: Dictionary mapping estimator names to the estimator
         :param x: Independant variable to be processed.
@@ -121,7 +132,7 @@ class CrossValidation:
         Run the cross-validation. It will run all estimators with the same data and cross-validation method. Outputs of the cross-validation will be saved in a CrossValidationOutput object.
 
         :param verbose: If to show progress.
-        :return: A CrossValidationOutput object.        
+        :return: A CrossValidationOutput object.
         """
         results = []
         p_bar = tqdm(
@@ -139,7 +150,14 @@ class CrossValidation:
                 {
                     self.ESTIMATOR_NAME_KEY: estimator_name,
                     **{
-                        k: {"train": v["train"][i], "test": v["test"][i]} if k == "indices" else v[i]
+                        k: (
+                            {
+                                self.INDICES_TRAIN_KEY: v[self.INDICES_TRAIN_KEY][i],
+                                self.INDICES_TEST_KEY: v[self.INDICES_TEST_KEY][i],
+                            }
+                            if k == self.INDICES_NAME_KEY
+                            else v[i]
+                        )
                         for k, v in cv_result.items()
                     },
                 }

--- a/tests/test_ml/test_cross_validation.py
+++ b/tests/test_ml/test_cross_validation.py
@@ -47,3 +47,16 @@ class TestCrossValidation:
         assert isinstance(cvo, CrossValidationOutput)
         assert set(cv.estimators.keys()) == set(cvo.estimators.keys())
         assert CrossValidation.ESTIMATOR_NAME_KEY in cvo.results_df.columns
+
+    def test_run_with_kwargs(self, cv):
+        kwargs = {
+            "return_train_score": True,
+            "return_indices": True,
+            "return_estimator": True,
+        }
+        cv = CrossValidation(cv.estimators, x=cv.x, y=cv.y, cv=cv.cv, cross_validate_kwargs=kwargs)
+        cvo = cv.run(verbose=False)
+        assert isinstance(cvo, CrossValidationOutput)
+        assert "train_score" in cvo.results_df.columns
+        assert CrossValidation.INDICES_NAME_KEY in cvo.results_df.columns
+        assert CrossValidation.ESTIMATOR_NAME_KEY in cvo.results_df.columns


### PR DESCRIPTION
# Description

Add support to handle returning the indices used by the CV method. If you pass `{'return_indices': true}` to the CrossValidation class, it will fail because it won't be able to deconstruct the `indices` key-value pair.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running 
      `uv run pytest tests --cov=src --cov-report=term-missing --durations=30 --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code is formatted using Black.
      You can do this by running `uv run black src tests`.
- [x] The imports are sorted using isort.
      You can do this by running `uv run isort src tests`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
