### PR TITLE
Support pennylane operations

### DIFF
--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -296,6 +296,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
             is_prep = self.apply_state_prep(op, index=i)
             if is_prep:
                 continue
+            op = self.convert_op_to_supported(op)
             op_list = self.contraction_strategy.get_next_operations(op)
             for j, op_j in enumerate(op_list):
                 if op_j is None:
@@ -332,6 +333,38 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         )
         self.close_p_bar()
         return self
+
+    def convert_op_to_supported(self, op: qml.operation.Operation) -> qml.operation.Operation:
+        """
+        Ensure an operation is supported by the device, converting native matchgates when possible.
+
+        If ``op`` is already a :class:`MatchgateOperation` or a
+        :class:`SingleParticleTransitionMatrixOperation` (or a subclass of either), or if it
+        already knows how to produce a single-particle transition matrix (it exposes a
+        ``to_sptm_operation`` method or a ``single_particle_transition_matrix`` attribute), it is
+        returned unchanged and handled downstream by :meth:`apply_op`. Otherwise, the operation's
+        matrix is fed to the :class:`MatchgateOperation` constructor, which validates that it is a
+        matchgate. If the matrix is a matchgate, the resulting :class:`MatchgateOperation` is
+        returned; if not, a :class:`DeviceError` is raised.
+
+        :param op: The operation to check and convert.
+        :type op: qml.operation.Operation
+        :return: A supported operation equivalent to ``op``.
+        :rtype: qml.operation.Operation
+        :raises DeviceError: If ``op`` is neither a supported operation nor a matchgate.
+        """
+        if isinstance(op, (MatchgateOperation, SingleParticleTransitionMatrixOperation)):
+            return op
+        if hasattr(op, "to_sptm_operation") or hasattr(op, "single_particle_transition_matrix"):
+            return op
+        try:
+            return MatchgateOperation(op.matrix(), wires=op.wires)
+        except Exception as error:
+            raise DeviceError(
+                f"The {self.name} device can only handle operations that are an instance of "
+                f"MatchgateOperation or SingleParticleTransitionMatrixOperation. "
+                f"The operation {op} is neither and could not be converted to a MatchgateOperation."
+            ) from error
 
     def apply_op(self, op: qml.operation.Operation) -> SingleParticleTransitionMatrixOperation:
         """
@@ -1063,12 +1096,23 @@ class NonInteractingFermionicDevice(qml.devices.Device):
     def _stopping_condition(self, op: qml.operation.Operator) -> bool:
         """Return True when an operator is natively supported by this device.
 
+        An operator is natively supported if its name is in ``_supported_ops`` or if it can be
+        converted to a :class:`MatchgateOperation` (i.e. it is a native matchgate such as
+        ``IsingXX``). Stopping the decomposition on native matchgates lets them reach
+        :meth:`apply_op`, where they are converted by :meth:`convert_op_to_supported`.
+
         :param op: The operator to check.
         :type op: qml.operation.Operator
         :return: True if the operator is natively supported.
         :rtype: bool
         """
-        return op.name in self._supported_ops
+        if op.name in self._supported_ops:
+            return True
+        try:
+            self.convert_op_to_supported(op)
+            return True
+        except DeviceError:
+            return False
 
     @property
     def covariance_matrix(self) -> TensorLike:

--- a/src/matchcake/operations/matchgate_operation.py
+++ b/src/matchcake/operations/matchgate_operation.py
@@ -68,6 +68,10 @@ class MatchgateOperation(Operation):
     num_wires = 2
     par_domain = "A"
 
+    # Positions of the matchgate matrix that must be zero (everything outside the outer
+    # corners and the inner 2x2 block, see the class docstring for the matrix layout).
+    MATCHGATE_ZERO_POSITIONS = ((0, 1), (0, 2), (1, 0), (1, 3), (2, 0), (2, 3), (3, 1), (3, 2))
+
     grad_method = "A"
     grad_recipe = None
 
@@ -398,6 +402,18 @@ class MatchgateOperation(Operation):
             )
         return check
 
+    def _check_structure_constraint(self) -> bool:
+        with torch.no_grad():
+            matrix = to_cpu(self.matrix())
+            off_structure = torch.stack([matrix[..., r, c] for r, c in self.MATCHGATE_ZERO_POSITIONS], dim=-1)
+            check = torch.allclose(off_structure, torch.zeros_like(off_structure), atol=1e-5)
+        if not check:
+            raise ValueError(
+                rf"The matrix does not have the matchgate structure. Expected zeros outside the "
+                rf"outer corners and the inner 2x2 block. Got {off_structure}."
+            )
+        return check
+
     def _check_det_constraint(self) -> bool:
         with torch.no_grad():
             outer_determinant = torch.linalg.det(self.outer_gate_data)
@@ -411,6 +427,7 @@ class MatchgateOperation(Operation):
         return check
 
     def _check_is_matchgate(self):
+        self._check_structure_constraint()
         self._check_m_m_dagger_constraint()
         self._check_m_dagger_m_constraint()  # pragma: no cover
         self._check_det_constraint()

--- a/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
@@ -358,6 +358,73 @@ class TestNIFDeviceMethodsAndProperties:
         sptm = dev.global_sptm
         assert sptm.matrix().shape == (1, 4, 4)
 
+    def test_convert_op_to_supported_passthrough_matchgate(self):
+        from matchcake.operations.matchgate_operation import MatchgateOperation
+
+        dev = NonInteractingFermionicDevice(wires=2)
+        op = MatchgateOperation.random(wires=[0, 1], seed=TEST_SEED)
+        assert dev.convert_op_to_supported(op) is op
+
+    def test_convert_op_to_supported_passthrough_sptm(self):
+        from matchcake.operations import SingleParticleTransitionMatrixOperation
+
+        dev = NonInteractingFermionicDevice(wires=2)
+        op = SingleParticleTransitionMatrixOperation(np.eye(4), wires=[0, 1])
+        assert dev.convert_op_to_supported(op) is op
+
+    def test_convert_op_to_supported_converts_native_matchgate(self):
+        from matchcake.operations.matchgate_operation import MatchgateOperation
+
+        dev = NonInteractingFermionicDevice(wires=2)
+        converted = dev.convert_op_to_supported(qml.IsingXX(0.5, wires=[0, 1]))
+        assert isinstance(converted, MatchgateOperation)
+
+    def test_convert_op_to_supported_non_matchgate_raises(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+        with pytest.raises(DeviceError, match="MatchgateOperation or SingleParticleTransitionMatrixOperation"):
+            dev.convert_op_to_supported(qml.CNOT(wires=[0, 1]))
+
+    def test_apply_generator_converts_native_matchgate(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+        dev.apply_generator([qml.IsingXX(0.5, wires=[0, 1])])
+        assert dev.global_sptm is not None
+
+    def test_stopping_condition_native_matchgate(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+        assert dev._stopping_condition(qml.IsingXX(0.5, wires=[0, 1])) is True
+        assert dev._stopping_condition(qml.CNOT(wires=[0, 1])) is False
+
+    def test_qnode_with_native_matchgate(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+
+        @qml.qnode(dev)
+        def circuit(theta):
+            qml.BasisState(np.array([0, 0]), wires=[0, 1])
+            qml.IsingXX(theta, wires=[0, 1])
+            return qml.probs(wires=[0, 1])
+
+        reference = qml.device("default.qubit", wires=2)
+
+        @qml.qnode(reference)
+        def reference_circuit(theta):
+            qml.BasisState(np.array([0, 0]), wires=[0, 1])
+            qml.IsingXX(theta, wires=[0, 1])
+            return qml.probs(wires=[0, 1])
+
+        np.testing.assert_allclose(np.asarray(circuit(0.5)), np.asarray(reference_circuit(0.5)), atol=1e-6)
+
+    def test_qnode_with_non_matchgate_raises(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+
+        @qml.qnode(dev)
+        def circuit():
+            qml.BasisState(np.array([0, 0]), wires=[0, 1])
+            qml.CNOT(wires=[0, 1])
+            return qml.probs(wires=[0, 1])
+
+        with pytest.raises(DeviceError):
+            circuit()
+
     def test_exact_expval_falls_back_to_probabilities(self):
         # Z-only weight-3 string with a non-(Basis/Product) state prep: the M-Pfaffian and
         # Clifford strategies decline, so exact_expval falls back to the probability strategy.

--- a/tests/test_operations/test_matchgate_operation.py
+++ b/tests/test_operations/test_matchgate_operation.py
@@ -88,6 +88,15 @@ class TestMatchgateOperation:
                     [0.0, 0, 0, 1.0],
                 ]
             ),
+            # CNOT: unitary with equal sub-determinants but without the matchgate structure.
+            np.array(
+                [
+                    [1.0, 0, 0, 0.0],
+                    [0, 1.0, 0.0, 0],
+                    [0, 0.0, 0.0, 1.0],
+                    [0.0, 0, 1.0, 0],
+                ]
+            ),
         ],
     )
     def test_init_from_not_matchgate(self, input_matrix):


### PR DESCRIPTION
# Description

This pull request enhances support for native matchgate operations in the `NonInteractingFermionicDevice` by introducing a conversion mechanism for operations, improving matchgate structure validation, and expanding test coverage. The main changes ensure that native matchgates like `IsingXX` are properly recognized and handled, while non-matchgate operations are rejected with clear errors.

**Device operation handling improvements:**

* Added a `convert_op_to_supported` method to `NIFDevice`, which converts operations to a supported form if possible (e.g., wraps native matchgates as `MatchgateOperation`), and raises a `DeviceError` for unsupported operations. This method is now called in `apply_generator` to ensure all operations are supported before further processing. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R299) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R337-R368)
* Updated the `_stopping_condition` method to recognize native matchgates as supported by attempting conversion with `convert_op_to_supported`.

**Matchgate structure validation:**

* Added a `_check_structure_constraint` method to `MatchgateOperation` to ensure the matrix has the correct matchgate structure (zeros in required positions), and included this check in the overall matchgate validation. [[1]](diffhunk://#diff-01732e5fe07337fa52229a332af9c478de58516b8ef8cac507dcea1a3bdeb08aR71-R74) [[2]](diffhunk://#diff-01732e5fe07337fa52229a332af9c478de58516b8ef8cac507dcea1a3bdeb08aR405-R416) [[3]](diffhunk://#diff-01732e5fe07337fa52229a332af9c478de58516b8ef8cac507dcea1a3bdeb08aR430)

**Testing enhancements:**

* Added comprehensive tests for the new conversion logic, including passthrough of supported operations, conversion of native matchgates, error handling for unsupported operations, and integration tests for circuits using native matchgates and non-matchgates.
* Added a test case to verify that matrices with correct determinants but incorrect matchgate structure (e.g., CNOT) are not accepted as matchgates.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
