### PR TITLE
Enhance dtype handling

### DIFF
--- a/src/matchcake/base/lookup_table.py
+++ b/src/matchcake/base/lookup_table.py
@@ -185,7 +185,11 @@ class NonInteractingFermionicLookupTable:
 
         batch_size = [self.batch_size] if self.batch_size else [1]
         obs_shape = [target_batch_size] + batch_size + [obs_size, obs_size]
-        obs = qml.math.convert_like(np.zeros(obs_shape, dtype=complex), self.transition_matrix)
+        obs = utils.math.convert_like_and_cast_to(
+            np.zeros(obs_shape, dtype=complex),
+            self.transition_matrix,
+            dtype=utils.math.complex_dtype_name_like(self.transition_matrix),
+        )
         obs[..., obs_indices[0], obs_indices[1]] = qml.math.transpose(
             lt_items[new_all_lt_indexes, ..., lt_item_rows, lt_item_cols], (0, -1, -2)
         )
@@ -523,7 +527,9 @@ class NonInteractingFermionicLookupTable:
                 new_shape = list(item_shape)
                 new_shape[-2] = max_dim_0
                 new_shape[-1] = max_dim_1
-                new_item = qml.math.convert_like(np.full(new_shape, fill_value=pad_value, dtype=complex), item)
+                new_item = utils.math.convert_and_cast_like(
+                    np.full(new_shape, fill_value=pad_value, dtype=complex), item
+                )
                 new_item[..., : item_shape[-2], : item_shape[-1]] = item
                 items[i] = new_item
             items = qml.math.stack(items)
@@ -604,7 +610,11 @@ class NonInteractingFermionicLookupTable:
 
         :return: the :math:`B` matrix.
         """
-        return utils.get_block_diagonal_matrix(self.n_particles)
+        return utils.math.convert_like_and_cast_to(
+            utils.get_block_diagonal_matrix(self.n_particles),
+            self.transition_matrix,
+            dtype=utils.math.complex_dtype_name_like(self.transition_matrix),
+        )
 
     @cached_property
     def block_bm_transition_transpose_matrix(self):
@@ -696,7 +706,7 @@ class NonInteractingFermionicLookupTable:
             matrix[..., :, :] = qml.math.eye(size, dtype=complex)
         else:
             matrix = np.eye(self.transition_matrix.shape[-1])
-        matrix = qml.math.convert_like(matrix, self.transition_matrix)
+        matrix = utils.math.convert_and_cast_like(matrix, self.transition_matrix)
         return matrix
 
     @cached_property

--- a/src/matchcake/devices/expval_strategies/clifford_expval/clifford_expval_strategy.py
+++ b/src/matchcake/devices/expval_strategies/clifford_expval/clifford_expval_strategy.py
@@ -122,7 +122,8 @@ class CliffordExpvalStrategy(ExpvalStrategy):
         observable: Operator,
         global_sptm: TensorLike,
     ):
-        global_sptm = to_tensor(global_sptm, dtype=torch.complex128)
+        is_complex = "complex" in qml.math.get_dtype_name(global_sptm).lower()
+        global_sptm = to_tensor(global_sptm, dtype=None if is_complex else torch.complex128)
         global_sptm = qml.math.einsum("...ij->...ji", global_sptm)  # TODO: why do I need this transpose?
         expvals = self._compute_full_clifford_expvals(state_prep_op, global_sptm)
         hamiltonian = self._format_observable(observable)

--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -208,12 +208,8 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         self._debugger = kwargs.get("debugger", None)
         self._init_kwargs = kwargs
 
-        self.R_DTYPE = torch_utils.DTYPES_TO_TORCH_TYPES.get(
-            kwargs.get("r_dtype"), kwargs.get("r_dtype", type(self).R_DTYPE)
-        )
-        self.C_DTYPE = torch_utils.DTYPES_TO_TORCH_TYPES.get(
-            kwargs.get("c_dtype"), kwargs.get("c_dtype", type(self).C_DTYPE)
-        )
+        self.R_DTYPE = torch_utils.get_torch_dtype(kwargs.get("r_dtype"), type(self).R_DTYPE)
+        self.C_DTYPE = torch_utils.get_torch_dtype(kwargs.get("c_dtype"), type(self).C_DTYPE)
         self._c_dtype_name = str(self.C_DTYPE).rsplit(".", 1)[-1]
         self._r_dtype_name = str(self.R_DTYPE).rsplit(".", 1)[-1]
 

--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -32,7 +32,8 @@ from ..utils import (
     torch_utils,
 )
 from ..utils.math import (
-    convert_and_cast_like,
+    complex_dtype_name_like,
+    convert_like_and_cast_to,
     fermionic_operator_matmul,
 )
 from .contraction_strategies import ContractionStrategy, get_contraction_strategy
@@ -72,8 +73,6 @@ def _nif_split_non_commuting(tape: QuantumScript):
 
 
 class NonInteractingFermionicDevice(qml.devices.Device):
-    _wires: Optional[Wires]
-
     r"""
     The Non-Interacting Fermionic Simulator device. This device simulates non-interacting fermions using
     matchgate operations and single particle transition matrices.
@@ -100,6 +99,12 @@ class NonInteractingFermionicDevice(qml.devices.Device):
     :type n_workers: int
     :keyword star_state_finding_strategy: The strategy to find the star state.
     :type star_state_finding_strategy: Union[str, StarStateFindingStrategy]
+    :keyword r_dtype: The real floating-point dtype used for real-valued tensors. Defaults to ``torch.float64``.
+    :type r_dtype: torch.dtype
+    :keyword c_dtype: The complex dtype used for complex-valued tensors throughout the pipeline (single-particle
+        transition matrices, lookup table, observables). Defaults to ``torch.complex128`` to preserve maximum
+        precision. Set to e.g. ``torch.complex64`` to reduce memory usage and computation cost.
+    :type c_dtype: torch.dtype
 
     :Note: This device is a simulator for non-interacting fermions. It is based on the ``default.qubit`` device.
     :Note: This device supports batch execution.
@@ -107,6 +112,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
     """
 
     name = "nif.qubit"
+    _wires: Optional[Wires]
 
     R_DTYPE = torch.float64
     C_DTYPE = torch.complex128
@@ -201,6 +207,15 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         super().__init__(wires=wires, shots=shots)
         self._debugger = kwargs.get("debugger", None)
         self._init_kwargs = kwargs
+
+        self.R_DTYPE = torch_utils.DTYPES_TO_TORCH_TYPES.get(
+            kwargs.get("r_dtype"), kwargs.get("r_dtype", type(self).R_DTYPE)
+        )
+        self.C_DTYPE = torch_utils.DTYPES_TO_TORCH_TYPES.get(
+            kwargs.get("c_dtype"), kwargs.get("c_dtype", type(self).C_DTYPE)
+        )
+        self._c_dtype_name = str(self.C_DTYPE).rsplit(".", 1)[-1]
+        self._r_dtype_name = str(self.R_DTYPE).rsplit(".", 1)[-1]
 
         self._star_state = None
         self._star_probability = None
@@ -382,6 +397,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
             instance of ``SingleParticleTransitionMatrixOperation``.
         """
         op_sptm = SingleParticleTransitionMatrixOperation.from_operation(op).pad(self.wires).matrix()
+        op_sptm = qml.math.cast(op_sptm, self._r_dtype_name)
         self._batched = self._batched or (qml.math.ndim(op_sptm) > 2)
         self.global_sptm = self.update_single_particle_transition_matrix(self._global_sptm, op_sptm)
         return self.global_sptm
@@ -1171,7 +1187,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         """
         if self._global_sptm is None:
             assert self.num_wires is not None
-            matrix = np.eye(2 * self.num_wires)[None, ...]
+            matrix = qml.math.cast(np.eye(2 * self.num_wires)[None, ...], self._r_dtype_name)
             if not self._batched:
                 matrix = matrix[0]
             return SingleParticleTransitionMatrixOperation(matrix, wires=self.wires)
@@ -1183,7 +1199,8 @@ class NonInteractingFermionicDevice(qml.devices.Device):
             value = SingleParticleTransitionMatrixOperation.from_operation(value)
         if not isinstance(value, SingleParticleTransitionMatrixOperation):
             value = SingleParticleTransitionMatrixOperation(value, wires=self.wires)
-        self._global_sptm = value
+        matrix = qml.math.cast(value.matrix(), self._r_dtype_name)
+        self._global_sptm = SingleParticleTransitionMatrixOperation(matrix, wires=value.wires, **value._hyperparameters)
         self.transition_matrix = None
 
     @property
@@ -1285,7 +1302,10 @@ class NonInteractingFermionicDevice(qml.devices.Device):
     @transition_matrix.setter
     def transition_matrix(self, value: Optional[TensorLike]) -> None:
         if self._global_sptm is not None and value is not None:
-            value = convert_and_cast_like(value, self._global_sptm.matrix())
+            global_sptm_matrix = self._global_sptm.matrix()
+            value = convert_like_and_cast_to(
+                value, global_sptm_matrix, dtype=complex_dtype_name_like(global_sptm_matrix)
+            )
         self._transition_matrix = value
         self._lookup_table = None
 

--- a/src/matchcake/operations/single_particle_transition_matrices/single_particle_transition_matrix.py
+++ b/src/matchcake/operations/single_particle_transition_matrices/single_particle_transition_matrix.py
@@ -65,6 +65,8 @@ class SingleParticleTransitionMatrixOperation(Operation):
     DEFAULT_CHECK_ANGLES = False
     DEFAULT_CLIP_ANGLES = True
     DEFAULT_NORMALIZE = False
+    DEFAULT_CHECK_REAL = True
+    REAL_PART_ATOL = 1e-6
 
     @staticmethod
     def make_wires_continuous(wires: Wires):
@@ -80,6 +82,35 @@ class SingleParticleTransitionMatrixOperation(Operation):
     ):
         unitary = SingleParticleTransitionMatrixOperation.to_unitary_matrix(params[0])
         return [qml.QubitUnitary(unitary, wires=wires)]
+
+    @staticmethod
+    def _enforce_real(matrix: TensorLike, check_real: bool) -> TensorLike:
+        """Return the real part of ``matrix``, keeping it real-valued (a floating-point dtype).
+
+        Real inputs are returned unchanged. Complex inputs (e.g. a matrix built from a matchgate)
+        have their imaginary part dropped via the differentiable ``qml.math.real``, so gradients flow
+        through. When ``check_real`` is True, the imaginary part must be negligible (within
+        :attr:`REAL_PART_ATOL`) or a ``ValueError`` is raised.
+
+        :param matrix: The candidate single-particle transition matrix.
+        :type matrix: TensorLike
+        :param check_real: Whether to verify that a complex input has a negligible imaginary part.
+        :type check_real: bool
+        :return: The real-valued matrix.
+        :rtype: TensorLike
+        :raises ValueError: If ``check_real`` is True and the imaginary part exceeds ``REAL_PART_ATOL``.
+        """
+        if "complex" not in qml.math.get_dtype_name(matrix).lower():
+            return matrix
+        if check_real:
+            atol = SingleParticleTransitionMatrixOperation.REAL_PART_ATOL
+            max_abs_imaginary = qml.math.max(qml.math.abs(qml.math.imag(matrix)))
+            if max_abs_imaginary > atol:
+                raise ValueError(
+                    f"The single-particle transition matrix must be real, but its maximum absolute "
+                    f"imaginary part is {max_abs_imaginary}, which exceeds {atol}."
+                )
+        return qml.math.real(matrix)
 
     @classmethod
     def clip_angles(cls, angles):
@@ -272,6 +303,7 @@ class SingleParticleTransitionMatrixOperation(Operation):
         clip_angles: bool = DEFAULT_CLIP_ANGLES,
         check_angles: bool = DEFAULT_CHECK_ANGLES,
         check_matrix: bool = DEFAULT_CHECK_MATRIX,
+        check_real: bool = DEFAULT_CHECK_REAL,
         normalize: bool = DEFAULT_NORMALIZE,
         **kwargs,
     ):
@@ -279,6 +311,12 @@ class SingleParticleTransitionMatrixOperation(Operation):
         Initialize an operation that applies a single-particle transition represented by the
         specified matrix with optional parameters for clipping angles, checking matrix and
         angle validity, and normalization.
+
+        The single-particle transition matrix is a real orthogonal matrix, so the stored matrix is
+        always real (a floating-point dtype). A complex matrix may be passed (for example, one built
+        from a matchgate), in which case its imaginary part is dropped after an optional check that it
+        is negligible. Dropping the imaginary part is differentiable, so gradients still flow through a
+        complex input.
 
         :param matrix: A tensor-like object defining the transition matrix.
         :param wires: Optional; Specifies the wires or subsystems the operation acts on. Can
@@ -290,14 +328,19 @@ class SingleParticleTransitionMatrixOperation(Operation):
             matrix. Defaults to `DEFAULT_CHECK_ANGLES`.
         :param check_matrix: Boolean flag indicating whether to check if the matrix lies
             within the SO(4) group. Defaults to `DEFAULT_CHECK_MATRIX`.
+        :param check_real: Boolean flag indicating whether to verify that a complex input matrix has a
+            negligible imaginary part (within `REAL_PART_ATOL`) before dropping it.
+            Defaults to `DEFAULT_CHECK_REAL`.
         :param normalize: Boolean flag indicating whether to orthonormalize the matrix
             prior to initialization. Defaults to `DEFAULT_NORMALIZE`.
         :param kwargs: Additional keyword arguments passed to parent classes or methods.
         :raises ValueError: If `check_matrix` is True and the provided matrix does not belong
-            to the SO(4) group.
+            to the SO(4) group, or if `check_real` is True and the imaginary part of `matrix`
+            exceeds `REAL_PART_ATOL`.
         """
         if normalize:
             matrix = orthonormalize(matrix)
+        matrix = self._enforce_real(matrix, check_real)
         self._matrix = matrix
         self._wires = wires
         super().__init__(matrix, wires=wires, id=id)
@@ -305,6 +348,7 @@ class SingleParticleTransitionMatrixOperation(Operation):
             "clip_angles": clip_angles,
             "check_angles": check_angles,
             "check_matrix": check_matrix,
+            "check_real": check_real,
         }
         if check_matrix:
             if not self.check_is_in_so4():
@@ -379,23 +423,19 @@ class SingleParticleTransitionMatrixOperation(Operation):
         return SingleParticleTransitionMatrixOperation(dagger(self.matrix()), wires=self.wires, **self._hyperparameters)
 
     def to_cuda(self):  # pragma: no cover
-        import torch  # pragma: no cover
-
         from ...utils import torch_utils  # pragma: no cover
 
         return SingleParticleTransitionMatrixOperation(  # pragma: no cover
-            torch_utils.to_cuda(self.matrix(), dtype=torch.complex128),  # pragma: no cover
+            torch_utils.to_cuda(self.matrix(), dtype=None),  # pragma: no cover
             wires=self.wires,  # pragma: no cover
             **self._hyperparameters,  # pragma: no cover
         )  # pragma: no cover
 
     def to_torch(self):
-        import torch
-
         from ...utils import torch_utils
 
         return SingleParticleTransitionMatrixOperation(
-            torch_utils.to_tensor(self.matrix(), dtype=torch.complex128),
+            torch_utils.to_tensor(self.matrix(), dtype=None),
             wires=self.wires,
             **self._hyperparameters,
         )
@@ -478,6 +518,15 @@ class SingleParticleTransitionMatrixOperation(Operation):
     @property
     def shape(self):
         return qml.math.shape(self._matrix)
+
+    @property
+    def dtype(self) -> str:
+        """The backend-agnostic dtype name of the underlying matrix.
+
+        :return: The dtype name (e.g. ``"complex128"``).
+        :rtype: str
+        """
+        return qml.math.get_dtype_name(self._matrix)
 
     @property
     def batch_size(self):

--- a/src/matchcake/utils/math.py
+++ b/src/matchcake/utils/math.py
@@ -11,6 +11,31 @@ from ..constants import (
 )
 from ..typing import TensorLike
 
+_COMPLEX_DTYPE_NAME_BY_PRECISION = {
+    "float16": "complex32",
+    "float32": "complex64",
+    "float64": "complex128",
+    "complex32": "complex32",
+    "complex64": "complex64",
+    "complex128": "complex128",
+}
+
+
+def complex_dtype_name_like(reference: TensorLike) -> str:
+    """Return the complex dtype name matching the floating-point precision of ``reference``.
+
+    Real references are mapped to the complex dtype with the same component precision
+    (``float32`` -> ``complex64``, ``float64`` -> ``complex128``), and complex references
+    keep their own precision. Unknown dtypes fall back to ``complex128``.
+
+    :param reference: Tensor whose precision determines the returned complex dtype.
+    :type reference: TensorLike
+    :return: A backend-agnostic complex dtype name (e.g. ``"complex64"``).
+    :rtype: str
+    """
+    name = qml.math.get_dtype_name(reference).lower()
+    return _COMPLEX_DTYPE_NAME_BY_PRECISION.get(name, "complex128")
+
 
 def convert_and_cast_like(tensor1, tensor2):
     r"""

--- a/src/matchcake/utils/torch_utils.py
+++ b/src/matchcake/utils/torch_utils.py
@@ -26,6 +26,12 @@ DTYPES_TO_TORCH_TYPES = {
 }
 
 
+def get_torch_dtype(dtype: Any, default: torch.dtype) -> torch.dtype:
+    if dtype is None:
+        return default
+    return DTYPES_TO_TORCH_TYPES.get(dtype, dtype)  # type: ignore[arg-type, return-value]
+
+
 def to_tensor(
     x: Any, dtype: Optional[torch.dtype] = torch.float64, device: Optional[torch.device] = None
 ) -> Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor, ...], Dict[str, torch.Tensor]]:

--- a/tests/test_devices/test_nif_device/test_nif_device_dtype.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_dtype.py
@@ -1,0 +1,131 @@
+import numpy as np
+import pennylane as qml
+import pytest
+import torch
+
+from matchcake import NonInteractingFermionicDevice
+from matchcake.operations import Rxx
+
+from ...configs import ATOL_MATRIX_COMPARISON, RTOL_MATRIX_COMPARISON, TEST_SEED, set_seed
+
+_DTYPE_CASES = [
+    pytest.param(torch.float64, "float64", "complex128", id="float64"),
+    pytest.param(torch.float32, "float32", "complex64", id="float32"),
+]
+
+
+class TestNIFDeviceDtype:
+    @classmethod
+    def setup_class(cls):
+        set_seed(TEST_SEED)
+
+    @staticmethod
+    def _probs_circuit(device: NonInteractingFermionicDevice):
+        @qml.qnode(device)
+        def circuit(x):
+            Rxx(x, wires=[0, 1])
+            return qml.probs(wires=[0, 1])
+
+        return circuit
+
+    @staticmethod
+    def _expval_circuit(device: NonInteractingFermionicDevice):
+        @qml.qnode(device)
+        def circuit(x):
+            Rxx(x, wires=[0, 1])
+            return qml.expval(qml.PauliZ(0) @ qml.PauliZ(1))
+
+        return circuit
+
+    def test_default_dtypes_are_complex128_and_float64(self):
+        device = NonInteractingFermionicDevice(wires=2)
+        assert device.C_DTYPE == torch.complex128
+        assert device.R_DTYPE == torch.float64
+
+    def test_instance_dtype_does_not_mutate_class_default(self):
+        NonInteractingFermionicDevice(wires=2, c_dtype=torch.complex64, r_dtype=torch.float32)
+        assert NonInteractingFermionicDevice.C_DTYPE == torch.complex128
+        assert NonInteractingFermionicDevice.R_DTYPE == torch.float64
+
+    def test_r_dtype_and_c_dtype_are_independent(self):
+        device = NonInteractingFermionicDevice(wires=2, c_dtype=torch.complex64, r_dtype=torch.float64)
+        assert device.C_DTYPE == torch.complex64
+        assert device.R_DTYPE == torch.float64
+
+    def test_numpy_dtype_argument_is_normalized_to_torch(self):
+        device = NonInteractingFermionicDevice(wires=2, c_dtype=np.complex64, r_dtype=np.float32)
+        assert device.C_DTYPE == torch.complex64
+        assert device.R_DTYPE == torch.float32
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_global_sptm_is_real_and_transition_matrix_is_complex(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        self._probs_circuit(device)(torch.tensor([0.1, 0.2], dtype=torch.float64))
+        assert device.global_sptm.dtype == real_name
+        assert qml.math.get_dtype_name(device.transition_matrix) == complex_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_global_sptm_identity_fallback_is_real(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        assert device.global_sptm.dtype == real_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_global_sptm_setter_normalizes_to_real_r_dtype(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        device.global_sptm = np.eye(4, dtype=np.complex128)
+        assert device.global_sptm.dtype == real_name
+        assert qml.math.get_dtype_name(device.transition_matrix) == complex_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_global_sptm_stays_real_after_each_applied_operation(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=3, r_dtype=r_dtype)
+        angles = torch.tensor([0.1, 0.2], dtype=torch.float64)
+        operations = [Rxx(angles, wires=[0, 1]), Rxx(angles, wires=[1, 2]), Rxx(angles, wires=[0, 1])]
+        for operation in operations:
+            device.apply_op(operation)
+            assert device.global_sptm.dtype == real_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_global_sptm_real_through_apply_generator(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=3, r_dtype=r_dtype)
+        angles = torch.tensor([0.1, 0.2], dtype=torch.float64)
+        device.apply_generator([Rxx(angles, wires=[0, 1]), Rxx(angles, wires=[1, 2]), Rxx(angles, wires=[0, 1])])
+        assert device.global_sptm.dtype == real_name
+        assert qml.math.get_dtype_name(device.transition_matrix) == complex_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_probs_dtype_matches_r_dtype_precision(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        probs = self._probs_circuit(device)(torch.tensor([0.1, 0.2], dtype=torch.float64))
+        assert qml.math.get_dtype_name(probs) == real_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_expval_is_real(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        expval = self._expval_circuit(device)(torch.tensor([0.1, 0.2], dtype=torch.float64))
+        assert "complex" not in qml.math.get_dtype_name(expval)
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_qnode_probs_preserve_precision_with_matching_input(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        probs = self._probs_circuit(device)(torch.tensor([0.1, 0.2], dtype=r_dtype))
+        assert qml.math.get_dtype_name(probs) == real_name
+
+    @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
+    def test_qnode_gradient_preserves_precision(self, r_dtype, real_name, complex_name):
+        device = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype)
+        circuit = self._probs_circuit(device)
+        angles = torch.tensor([0.1, 0.2], dtype=r_dtype, requires_grad=True)
+        circuit(angles).sum().backward()
+        assert qml.math.get_dtype_name(angles.grad) == real_name
+
+    def test_lower_precision_probs_match_default_within_tolerance(self):
+        x = torch.tensor([0.1, 0.2], dtype=torch.float64)
+        probs_default = self._probs_circuit(NonInteractingFermionicDevice(wires=2))(x)
+        probs_low = self._probs_circuit(NonInteractingFermionicDevice(wires=2, r_dtype=torch.float32))(x)
+        np.testing.assert_allclose(
+            probs_low.detach().numpy(),
+            probs_default.detach().numpy(),
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )

--- a/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
@@ -282,7 +282,8 @@ class TestNIFDeviceMethodsAndProperties:
         dev = NonInteractingFermionicDevice(wires=2)
         sptm = SingleParticleTransitionMatrixOperation(np.eye(4), wires=[0, 1])
         dev.global_sptm = sptm
-        assert dev._global_sptm is sptm
+        assert dev._global_sptm.dtype == "float64"
+        np.testing.assert_allclose(dev._global_sptm.matrix(), np.eye(4))
 
     def test_execute_single_quantum_script_directly(self):
         dev = NonInteractingFermionicDevice(wires=2)

--- a/tests/test_operations/test_sptms/test_single_particle_transition_matrix.py
+++ b/tests/test_operations/test_sptms/test_single_particle_transition_matrix.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pennylane as qml
 import pytest
 import torch
 
-from matchcake.operations import MatchgateOperation
+from matchcake.operations import MatchgateOperation, Rxx
 from matchcake.operations.single_particle_transition_matrices import (
     SingleParticleTransitionMatrixOperation,
     SptmCompRyRy,
@@ -11,6 +12,8 @@ from matchcake.utils import torch_utils
 from matchcake.utils.math import svd
 
 from ...configs import (
+    ATOL_MATRIX_COMPARISON,
+    RTOL_MATRIX_COMPARISON,
     TEST_SEED,
     set_seed,
 )
@@ -28,6 +31,89 @@ class TestSingleParticleTransitionMatrixOperation:
     @pytest.fixture
     def input_matrix(self, batch_size, size):
         return np.random.random((batch_size, 2 * size, 2 * size))
+
+    @pytest.mark.parametrize(
+        "matrix_dtype, expected_name",
+        [
+            (np.complex128, "float64"),
+            (np.complex64, "float32"),
+            (np.float64, "float64"),
+            (np.float32, "float32"),
+            (torch.complex64, "float32"),
+            (torch.complex128, "float64"),
+        ],
+    )
+    def test_dtype_property_returns_real_backend_agnostic_name(self, batch_size, size, matrix_dtype, expected_name):
+        # The SPTM is real-valued: a complex input is stored as its real counterpart, so the dtype
+        # property always reports a floating-point dtype name.
+        shape = (batch_size, 2 * size, 2 * size)
+        if isinstance(matrix_dtype, torch.dtype):
+            matrix = torch.zeros(shape, dtype=matrix_dtype)
+        else:
+            matrix = np.zeros(shape, dtype=matrix_dtype)
+        operation = SingleParticleTransitionMatrixOperation(matrix, wires=np.arange(size))
+        assert operation.dtype == expected_name
+
+    @pytest.mark.parametrize("matrix_dtype, expected_name", [(np.float32, "float32"), (np.float64, "float64")])
+    def test_to_torch_preserves_matrix_dtype(self, batch_size, size, matrix_dtype, expected_name):
+        matrix = np.random.random((batch_size, 2 * size, 2 * size)).astype(matrix_dtype)
+        operation = SingleParticleTransitionMatrixOperation(matrix, wires=np.arange(size)).to_torch()
+        assert isinstance(operation.matrix(), torch.Tensor)
+        assert operation.dtype == expected_name
+
+    def test_matrix_is_always_real(self, batch_size, size):
+        complex_matrix = np.random.random((batch_size, 2 * size, 2 * size)).astype(np.complex128)
+        operation = SingleParticleTransitionMatrixOperation(complex_matrix, wires=np.arange(size))
+        assert "complex" not in operation.dtype
+        assert "complex" not in qml.math.get_dtype_name(operation.matrix())
+
+    def test_constructor_drops_negligible_imaginary_part(self, batch_size, size):
+        real_part = np.random.random((batch_size, 2 * size, 2 * size))
+        complex_matrix = real_part + 1e-9j * np.random.random((batch_size, 2 * size, 2 * size))
+        operation = SingleParticleTransitionMatrixOperation(complex_matrix, wires=np.arange(size))
+        np.testing.assert_allclose(
+            qml.math.cast(operation.matrix(), "float64"),
+            real_part,
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    def test_constructor_raises_on_significant_imaginary_part(self, batch_size, size):
+        complex_matrix = np.random.random((batch_size, 2 * size, 2 * size)).astype(np.complex128)
+        complex_matrix += 1j * np.random.random((batch_size, 2 * size, 2 * size))
+        with pytest.raises(ValueError, match="must be real"):
+            SingleParticleTransitionMatrixOperation(complex_matrix, wires=np.arange(size), check_real=True)
+
+    def test_constructor_does_not_check_imaginary_when_check_real_false(self, batch_size, size):
+        complex_matrix = np.random.random((batch_size, 2 * size, 2 * size)).astype(np.complex128)
+        complex_matrix += 1j * np.random.random((batch_size, 2 * size, 2 * size))
+        operation = SingleParticleTransitionMatrixOperation(complex_matrix, wires=np.arange(size), check_real=False)
+        assert "complex" not in operation.dtype
+
+    def test_gradient_flows_through_complex_input(self, batch_size, size):
+        def sptm_from_complex(real_matrix):
+            complex_matrix = qml.math.cast(real_matrix, "complex128")
+            return SingleParticleTransitionMatrixOperation(complex_matrix, wires=np.arange(size)).matrix()
+
+        assert torch.autograd.gradcheck(
+            sptm_from_complex,
+            torch_utils.to_tensor(np.random.random((batch_size, 2 * size, 2 * size)), torch.double).requires_grad_(),
+            raise_exception=True,
+            check_undefined_grad=False,
+        )
+
+    def test_gradient_flows_through_matchgate_built_sptm(self, batch_size, size):
+        # Building an SPTM from a matchgate goes through a complex matrix whose imaginary part is
+        # numerically zero. The gradient must still flow back to the (real) matchgate angles.
+        def sptm_from_matchgate(angles):
+            return SingleParticleTransitionMatrixOperation.from_operation(Rxx(angles, wires=[0, 1])).matrix()
+
+        assert torch.autograd.gradcheck(
+            sptm_from_matchgate,
+            torch_utils.to_tensor(np.random.random(batch_size), torch.double).requires_grad_(),
+            raise_exception=True,
+            check_undefined_grad=False,
+        )
 
     def test_sptm_sum_gradient_check(self, input_matrix):
         def sptm_sum(p):
@@ -114,8 +200,9 @@ class TestSingleParticleTransitionMatrixOperation:
 
     def test_real(self, batch_size, size):
         matrix = np.random.random((batch_size, 2 * size, 2 * size)).astype(complex)
-        matrix += 1j * np.random.random((batch_size, 2 * size, 2 * size))
+        matrix += 1e-9j * np.random.random((batch_size, 2 * size, 2 * size))
         sptm = SingleParticleTransitionMatrixOperation(matrix=matrix, wires=np.arange(size))
+        assert "complex" not in sptm.dtype
         real_sptm = sptm.real()
         assert isinstance(real_sptm, SingleParticleTransitionMatrixOperation)
 

--- a/tests/test_utils/test_math.py
+++ b/tests/test_utils/test_math.py
@@ -6,6 +6,7 @@ from matchcake import utils
 from matchcake.utils.math import (
     check_is_unitary,
     circuit_matmul,
+    complex_dtype_name_like,
     convert_1d_to_2d_indexes,
     convert_2d_to_1d_indexes,
     convert_tensors_to_same_type,
@@ -135,6 +136,21 @@ def test_random_index_3d_none(probs_shape):
 
 
 class TestMath:
+    @pytest.mark.parametrize(
+        "reference, expected_name",
+        [
+            (torch.zeros(2, dtype=torch.float32), "complex64"),
+            (torch.zeros(2, dtype=torch.float64), "complex128"),
+            (torch.zeros(2, dtype=torch.complex64), "complex64"),
+            (torch.zeros(2, dtype=torch.complex128), "complex128"),
+            (np.zeros(2, dtype=np.float32), "complex64"),
+            (np.zeros(2, dtype=np.float64), "complex128"),
+            (np.zeros(2, dtype=np.int64), "complex128"),
+        ],
+    )
+    def test_complex_dtype_name_like(self, reference, expected_name):
+        assert complex_dtype_name_like(reference) == expected_name
+
     def test_convert_and_cast_like(self):
         source = np.random.uniform(-10, 10, (4, 3)).astype(np.float32)
         target = np.random.uniform(-10, 10, (4, 3)).astype(np.float64)


### PR DESCRIPTION
# Description

This pull request introduces improved and more consistent handling of real and complex data types throughout the codebase, especially for single-particle transition matrices and device internals. It adds new utilities for inferring the correct complex dtype, ensures matrices are properly cast and checked for realness, and updates device and operation classes to respect user-specified dtypes. This improves numerical precision, device interoperability, and memory efficiency.

**Device dtype and casting improvements:**

* Added `r_dtype` and `c_dtype` keyword arguments to `NonInteractingFermionicDevice` for user control of real and complex tensor dtypes; device now stores and uses these dtypes throughout its pipeline, improving precision and memory handling. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R102-R115) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R211-R219)
* Ensured all transition matrices and related tensors are cast to the correct dtype using new utility functions (`convert_like_and_cast_to`, `complex_dtype_name_like`) in both getter/setter and operation application methods. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R400) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L1174-R1190) [[3]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L1186-R1203) [[4]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L1288-R1308) [[5]](diffhunk://#diff-81a4a423a6488992df58db5981d7806922ed105605805c08b7ce40c1a9848ca8L188-R192) [[6]](diffhunk://#diff-81a4a423a6488992df58db5981d7806922ed105605805c08b7ce40c1a9848ca8L526-R532) [[7]](diffhunk://#diff-81a4a423a6488992df58db5981d7806922ed105605805c08b7ce40c1a9848ca8L607-R617) [[8]](diffhunk://#diff-81a4a423a6488992df58db5981d7806922ed105605805c08b7ce40c1a9848ca8L699-R709)

**SingleParticleTransitionMatrixOperation enhancements:**

* Added logic to ensure single-particle transition matrices are real-valued: complex inputs are checked (with tolerance) and their imaginary part is dropped in a differentiable way; this is now the default and can be controlled via a `check_real` argument. [[1]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R86-R114) [[2]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R306) [[3]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R315-R320) [[4]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R331-R351)
* Updated docstrings to clarify matrix requirements and new behavior for real/complex handling. [[1]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R315-R320) [[2]](diffhunk://#diff-a9a41b2651dde0003d6643508e86650aee045b81b34b07ab24651b74578ff265R331-R351)
* Added a `dtype` property to `SingleParticleTransitionMatrixOperation` for backend-agnostic dtype introspection.
* Updated `to_torch` and `to_cuda` methods to infer dtype from the matrix instead of forcing `complex128`, supporting user-specified dtypes.

**Math utilities:**

* Added `complex_dtype_name_like` utility to determine the appropriate complex dtype for a given tensor, supporting consistent casting and precision.

**Other improvements:**

* Improved dtype inference and casting in Clifford expectation value strategy to avoid unnecessary conversions when already complex.
* Minor refactoring and code cleanup in device and utility imports. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L35-R36) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L75-L76)

These changes collectively make dtype handling more robust, flexible, and explicit across the codebase, reducing subtle bugs and improving user control over numerical precision.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [ ] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
