### PR TITLE
139 sector pfaffian features hardcodes float64 internally precision not controllable gap vs 129

### DIFF
--- a/src/matchcake/devices/expval_strategies/m_pfaffian/_extended_covariance.py
+++ b/src/matchcake/devices/expval_strategies/m_pfaffian/_extended_covariance.py
@@ -6,6 +6,7 @@ import torch
 
 from ....typing import TensorLike
 from ....utils.math import convert_and_cast_like
+from ....utils.torch_utils import infer_complex_dtype, infer_real_dtype
 
 
 def displacement_vector(
@@ -25,11 +26,15 @@ def displacement_vector(
     :param wires: Wire labels (unused for the computation; here for API consistency).
     :return: Real tensor of shape (2n,).
     """
+    # Preserve the precision of the input amplitudes (complex64 -> float32) instead
+    # of forcing complex128/float64.
+    c_dtype = infer_complex_dtype(product_state_amplitudes)
+    r_dtype = infer_real_dtype(product_state_amplitudes)
     psi = torch.as_tensor(
         np.array(product_state_amplitudes)
         if not isinstance(product_state_amplitudes, torch.Tensor)
         else product_state_amplitudes,
-        dtype=torch.complex128,
+        dtype=c_dtype,
     )
     alpha = psi[..., 0]  # (..., n)
     beta = psi[..., 1]  # (..., n)
@@ -45,15 +50,15 @@ def displacement_vector(
     if n > 1:
         z_prod = torch.cat(
             [
-                torch.ones(batch_shape + (1,), dtype=torch.float64, device=psi.device),
+                torch.ones(batch_shape + (1,), dtype=r_dtype, device=psi.device),
                 torch.cumprod(z[..., :-1], dim=-1),
             ],
             dim=-1,
         )  # (..., n)
     else:
-        z_prod = torch.ones(batch_shape + (n,), dtype=torch.float64, device=psi.device)
+        z_prod = torch.ones(batch_shape + (n,), dtype=r_dtype, device=psi.device)
 
-    d = torch.zeros(batch_shape + (2 * n,), dtype=torch.float64, device=psi.device)
+    d = torch.zeros(batch_shape + (2 * n,), dtype=r_dtype, device=psi.device)
     d[..., 0::2] = z_prod * x  # <c_{2k}>   = z_prod[k] * <X_k>
     d[..., 1::2] = z_prod * y  # <c_{2k+1}> = z_prod[k] * <Y_k>
 
@@ -74,16 +79,17 @@ def extended_covariance_matrix(
     :param displacement: (..., 2n) real displacement vector d[mu] = <c_mu>.
     :return: (..., 2n+1, 2n+1) extended covariance matrix.
     """
-    cov_matrix_t = torch.as_tensor(qml.math.real(cov_matrix), dtype=torch.float64)
+    r_dtype = infer_real_dtype(cov_matrix)
+    cov_matrix_t = torch.as_tensor(qml.math.real(cov_matrix), dtype=r_dtype)
     d = torch.as_tensor(
         np.array(displacement) if not isinstance(displacement, torch.Tensor) else displacement,
-        dtype=torch.float64,
+        dtype=r_dtype,
     )
     batch = cov_matrix_t.shape[:-2]
 
     d_col = d.unsqueeze(-1)  # (..., 2n, 1)
     neg_d_row = -d.unsqueeze(-2)  # (..., 1, 2n)
-    zero_corner = torch.zeros(*batch, 1, 1, dtype=torch.float64, device=cov_matrix_t.device)
+    zero_corner = torch.zeros(*batch, 1, 1, dtype=r_dtype, device=cov_matrix_t.device)
 
     top = torch.cat([cov_matrix_t, d_col], dim=-1)  # (..., 2n, 2n+1)
     bottom = torch.cat([neg_d_row, zero_corner], dim=-1)  # (..., 1,  2n+1)
@@ -104,13 +110,14 @@ def sptm_lift(Q: TensorLike) -> TensorLike:
     :param Q: (..., 2n, 2n) orthogonal SPTM.
     :return: (..., 2n+1, 2n+1) lifted SPTM.
     """
-    Q_t = torch.as_tensor(qml.math.real(Q), dtype=torch.float64)
+    r_dtype = infer_real_dtype(Q)
+    Q_t = torch.as_tensor(qml.math.real(Q), dtype=r_dtype)
     batch = Q_t.shape[:-2]
     two_n = Q_t.shape[-1]
 
-    zeros_col = torch.zeros(*batch, two_n, 1, dtype=torch.float64, device=Q_t.device)
-    zeros_row = torch.zeros(*batch, 1, two_n, dtype=torch.float64, device=Q_t.device)
-    one_corner = torch.ones(*batch, 1, 1, dtype=torch.float64, device=Q_t.device)
+    zeros_col = torch.zeros(*batch, two_n, 1, dtype=r_dtype, device=Q_t.device)
+    zeros_row = torch.zeros(*batch, 1, two_n, dtype=r_dtype, device=Q_t.device)
+    one_corner = torch.ones(*batch, 1, 1, dtype=r_dtype, device=Q_t.device)
 
     top = torch.cat([Q_t, zeros_col], dim=-1)  # (..., 2n, 2n+1)
     bottom = torch.cat([zeros_row, one_corner], dim=-1)  # (..., 1,  2n+1)

--- a/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
+++ b/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
@@ -9,7 +9,7 @@ from pennylane.pauli import pauli_word_to_string
 from ....operations.state_preparation.product_state import ProductState
 from ....typing import TensorLike
 from ....utils import JordanWigner
-from ....utils._pfaffian import sector_pfaffian_features
+from ....utils._pfaffian import infer_real_dtype, sector_pfaffian_features
 from ....utils.math import convert_and_cast_like
 from ..expval_strategy import ExpvalStrategy
 
@@ -101,18 +101,21 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
             sector = len(ext_index_set)
             terms_by_sector.setdefault(sector, []).append((ext_index_set, ext_phase, term_idx))
 
+        r_dtype = infer_real_dtype(ext_cov_matrix)
         pf_values: dict[int, TensorLike] = {}
         for sector, items in terms_by_sector.items():
             index_sets = np.stack([item[0] for item in items])  # (n_terms, sector)
             if sector == 0:
-                pf_values[sector] = torch.ones(len(items), dtype=torch.float64)
+                pf_values[sector] = torch.ones(len(items), dtype=r_dtype)
             elif sector == 2:
                 i_idx = index_sets[:, 0]
                 j_idx = index_sets[:, 1]
-                ext_cov_matrix_t = torch.as_tensor(qml.math.real(ext_cov_matrix), dtype=torch.float64)
+                ext_cov_matrix_t = torch.as_tensor(qml.math.real(ext_cov_matrix), dtype=r_dtype)
                 pf_values[sector] = ext_cov_matrix_t[..., i_idx, j_idx]  # (..., n_terms)
             else:
-                pf_values[sector] = sector_pfaffian_features(ext_cov_matrix, index_sets)  # (..., n_terms)
+                pf_values[sector] = sector_pfaffian_features(
+                    ext_cov_matrix, index_sets, dtype=r_dtype
+                )  # (..., n_terms)
 
         total_re: Any = np.float64(0.0)
         for sector, items in terms_by_sector.items():

--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -1158,9 +1158,10 @@ class NonInteractingFermionicDevice(qml.devices.Device):
             raise ValueError(
                 f"Extended covariance matrix requires a ProductState or BasisState. Got {type(state_prep)}."
             )
-        # Build tilde_Lambda_0 from the initial state
-        amplitudes = state_prep.data[0]  # (n, 2) complex
-        cov0 = state_prep.covariance_matrix  # (2n, 2n)
+        # Build tilde_Lambda_0 from the initial state. Cast to the device's configured
+        # precision so r_dtype/c_dtype control the whole m-Pfaffian pipeline.
+        amplitudes = qml.math.cast(state_prep.data[0], self._c_dtype_name)  # (n, 2) complex
+        cov0 = qml.math.cast(state_prep.covariance_matrix, self._r_dtype_name)  # (2n, 2n)
         d0 = _displacement_vector(amplitudes, self.wires)  # (2n,)
         ext_cov0 = _extended_covariance_matrix(cov0, d0)  # (2n+1, 2n+1)
 

--- a/src/matchcake/operations/state_preparation/product_state.py
+++ b/src/matchcake/operations/state_preparation/product_state.py
@@ -8,6 +8,7 @@ from pennylane.operation import StatePrepBase
 from pennylane.wires import Wires, WiresLike
 
 from ...typing import TensorLike
+from ...utils.torch_utils import infer_complex_dtype, infer_real_dtype, torch_dtype_name
 
 
 class ProductState(StatePrepBase):
@@ -116,10 +117,13 @@ class ProductState(StatePrepBase):
                 f"complex amplitudes."
             )
 
-        # Cast to complex if not already (qml.math.iscomplexobj has no torch dispatch)
+        # Cast to complex if not already (qml.math.iscomplexobj has no torch dispatch).
+        # The complex precision is inferred from the input so that a float32 / complex64
+        # state is not silently upcast to complex128 (precision is user-controllable).
         is_complex = torch.is_complex(state) if isinstance(state, torch.Tensor) else qml.math.iscomplexobj(state)
         if not is_complex:
-            state = qml.math.cast(state, dtype=complex)
+            c_dtype_name = torch_dtype_name(infer_complex_dtype(state))
+            state = qml.math.cast(state, dtype=c_dtype_name)
 
         if validate_norm:
             # Per-qubit norms: sum over the trailing (alpha, beta) axis.
@@ -181,13 +185,16 @@ class ProductState(StatePrepBase):
         y = 2.0 * qml.math.imag(qml.math.conj(alpha) * beta)  # <Y_k>
         z = qml.math.abs(alpha) ** 2 - qml.math.abs(beta) ** 2  # <Z_k>
 
-        # Convert to real torch.Tensors on the appropriate dtype.
-        x = qml.math.cast(qml.math.real(x), dtype=float)
-        y = qml.math.cast(qml.math.real(y), dtype=float)
-        z = qml.math.cast(qml.math.real(z), dtype=float)
-        x = self._as_torch(x)
-        y = self._as_torch(y)
-        z = self._as_torch(z)
+        # Convert to real torch.Tensors, preserving the precision of the amplitudes
+        # (complex64 -> float32, complex128 -> float64) instead of forcing float64.
+        r_dtype = infer_real_dtype(psi)
+        r_dtype_name = torch_dtype_name(r_dtype)
+        x = qml.math.cast(qml.math.real(x), dtype=r_dtype_name)
+        y = qml.math.cast(qml.math.real(y), dtype=r_dtype_name)
+        z = qml.math.cast(qml.math.real(z), dtype=r_dtype_name)
+        x = self._as_torch(x, dtype=r_dtype)
+        y = self._as_torch(y, dtype=r_dtype)
+        z = self._as_torch(z, dtype=r_dtype)
 
         batch_shape = tuple(x.shape[:-1])
         cov = torch.zeros(batch_shape + (2 * n, 2 * n), dtype=x.dtype, device=x.device)
@@ -305,15 +312,18 @@ class ProductState(StatePrepBase):
         full_perm = list(range(nb)) + [nb + p for p in perm]
         return qml.math.transpose(qml.math.reshape(full, batch_shape + (2,) * n_total), full_perm)
 
-    def _as_torch(self, x):
+    def _as_torch(self, x, dtype: Optional[torch.dtype] = None):
         """
         Convert a tensor-like to a real torch.Tensor, no-op if already one.
 
-        TODO: control dtype
+        :param dtype: Target real dtype for non-torch inputs. Defaults to the
+            precision inferred from ``x`` (so float32 inputs stay float32).
         """
         if isinstance(x, torch.Tensor):
             return x
-        return torch.as_tensor(np.asarray(x), dtype=torch.float64)
+        if dtype is None:
+            dtype = infer_real_dtype(x)
+        return torch.as_tensor(np.asarray(x), dtype=dtype)
 
     def basis_state_bits(self) -> np.ndarray:
         r"""Integer bit array. Raises :class:`ValueError` if not a basis state.

--- a/src/matchcake/utils/_pfaffian.py
+++ b/src/matchcake/utils/_pfaffian.py
@@ -11,8 +11,36 @@ from pennylane.typing import TensorLike
 from . import torch_utils
 from .math import convert_and_cast_like
 
+_COMPLEX_TO_REAL_DTYPE = {
+    torch.complex32: torch.float16,
+    torch.complex64: torch.float32,
+    torch.complex128: torch.float64,
+}
 
-def signed_pfaffian(matrix: TensorLike) -> TensorLike:
+
+def infer_real_dtype(tensor: TensorLike) -> torch.dtype:
+    """
+    Infer the real-valued ``torch`` dtype matching the precision of ``tensor``.
+
+    Complex inputs map to their real counterpart (e.g. ``complex128 -> float64``),
+    floating inputs keep their precision, and non-floating inputs fall back to
+    ``float64``.
+
+    :param tensor: Tensor (torch, numpy, ...) whose precision is inspected.
+    :return: A real ``torch.dtype``.
+    """
+    if isinstance(tensor, torch.Tensor):
+        dtype = tensor.dtype
+    else:
+        dtype = torch.as_tensor(np.asarray(tensor)).dtype
+    if dtype in _COMPLEX_TO_REAL_DTYPE:
+        return _COMPLEX_TO_REAL_DTYPE[dtype]
+    if dtype.is_floating_point:
+        return dtype
+    return torch.float64
+
+
+def signed_pfaffian(matrix: TensorLike, dtype: Optional[torch.dtype] = None) -> TensorLike:
     """
     Compute the signed Pfaffian of a real antisymmetric matrix (or batch).
 
@@ -21,11 +49,17 @@ def signed_pfaffian(matrix: TensorLike) -> TensorLike:
     arbitrary leading batch dimensions.
 
     :param matrix: Real antisymmetric matrix of even size (..., 2k, 2k).
+    :param dtype: Real working precision for the internal computation. Defaults to
+        ``None``, in which case the precision is inferred from ``matrix`` (e.g. a
+        ``float32``/``complex64`` input keeps ``float32`` internals). Pass an
+        explicit real dtype to override.
     :return: Signed Pfaffian of shape (...,).
     """
+    if dtype is None:
+        dtype = infer_real_dtype(matrix)
     if not isinstance(matrix, torch.Tensor):
-        matrix = torch.as_tensor(qml.math.real(matrix), dtype=torch.float64)
-    A = matrix.to(torch.float64)
+        matrix = torch.as_tensor(qml.math.real(matrix), dtype=dtype)
+    A = matrix.to(dtype)
     shape = A.shape
     n = shape[-1]
 
@@ -79,6 +113,7 @@ def signed_pfaffian(matrix: TensorLike) -> TensorLike:
 def sector_pfaffian_features(
     cov_matrix: TensorLike,
     index_sets: np.ndarray,
+    dtype: Optional[torch.dtype] = None,
 ) -> TensorLike:
     """
     Return (..., n_terms) tensor of signed Pfaffians of (submatrix_size x submatrix_size)
@@ -86,9 +121,15 @@ def sector_pfaffian_features(
 
     :param cov_matrix: (..., D, D) antisymmetric matrix (or batch).
     :param index_sets: (n_terms, submatrix_size) integer array of Majorana index tuples.
+    :param dtype: Real working precision for the internal computation. Defaults to
+        ``None``, in which case the precision is inferred from ``cov_matrix`` (e.g. a
+        ``float32``/``complex64`` input keeps ``float32`` internals, avoiding the
+        ~2x memory of forcing ``float64``). Pass an explicit real dtype to override.
     :return: (..., n_terms) Pfaffians.
     """
-    cov_matrix_t = torch.as_tensor(qml.math.real(cov_matrix), dtype=torch.float64)
+    if dtype is None:
+        dtype = infer_real_dtype(cov_matrix)
+    cov_matrix_t = torch.as_tensor(qml.math.real(cov_matrix), dtype=dtype)
     index_sets = np.asarray(index_sets)  # (n_terms, submatrix_size)
     n_terms, submatrix_size = index_sets.shape
     row_indices = index_sets[:, :, None]  # (n_terms, submatrix_size, 1)

--- a/src/matchcake/utils/_pfaffian.py
+++ b/src/matchcake/utils/_pfaffian.py
@@ -10,34 +10,7 @@ from pennylane.typing import TensorLike
 
 from . import torch_utils
 from .math import convert_and_cast_like
-
-_COMPLEX_TO_REAL_DTYPE = {
-    torch.complex32: torch.float16,
-    torch.complex64: torch.float32,
-    torch.complex128: torch.float64,
-}
-
-
-def infer_real_dtype(tensor: TensorLike) -> torch.dtype:
-    """
-    Infer the real-valued ``torch`` dtype matching the precision of ``tensor``.
-
-    Complex inputs map to their real counterpart (e.g. ``complex128 -> float64``),
-    floating inputs keep their precision, and non-floating inputs fall back to
-    ``float64``.
-
-    :param tensor: Tensor (torch, numpy, ...) whose precision is inspected.
-    :return: A real ``torch.dtype``.
-    """
-    if isinstance(tensor, torch.Tensor):
-        dtype = tensor.dtype
-    else:
-        dtype = torch.as_tensor(np.asarray(tensor)).dtype
-    if dtype in _COMPLEX_TO_REAL_DTYPE:
-        return _COMPLEX_TO_REAL_DTYPE[dtype]
-    if dtype.is_floating_point:
-        return dtype
-    return torch.float64
+from .torch_utils import infer_real_dtype
 
 
 def signed_pfaffian(matrix: TensorLike, dtype: Optional[torch.dtype] = None) -> TensorLike:

--- a/src/matchcake/utils/torch_utils.py
+++ b/src/matchcake/utils/torch_utils.py
@@ -32,6 +32,65 @@ def get_torch_dtype(dtype: Any, default: torch.dtype) -> torch.dtype:
     return DTYPES_TO_TORCH_TYPES.get(dtype, dtype)  # type: ignore[arg-type, return-value]
 
 
+COMPLEX_TO_REAL_DTYPE = {
+    torch.complex32: torch.float16,
+    torch.complex64: torch.float32,
+    torch.complex128: torch.float64,
+}
+REAL_TO_COMPLEX_DTYPE = {real: complex_ for complex_, real in COMPLEX_TO_REAL_DTYPE.items()}
+
+
+def _torch_dtype_of(tensor: Any) -> torch.dtype:
+    if isinstance(tensor, torch.Tensor):
+        return tensor.dtype
+    return torch.as_tensor(np.asarray(tensor)).dtype
+
+
+def infer_real_dtype(tensor: Any, default: torch.dtype = torch.float64) -> torch.dtype:
+    """
+    Infer the real-valued ``torch`` dtype matching the precision of ``tensor``.
+
+    Complex inputs map to their real counterpart (e.g. ``complex128 -> float64``),
+    floating inputs keep their precision, and non-floating inputs fall back to
+    ``default``.
+
+    :param tensor: Tensor (torch, numpy, ...) whose precision is inspected.
+    :param default: Dtype returned for non-floating inputs.
+    :return: A real ``torch.dtype``.
+    """
+    dtype = _torch_dtype_of(tensor)
+    if dtype in COMPLEX_TO_REAL_DTYPE:
+        return COMPLEX_TO_REAL_DTYPE[dtype]
+    if dtype.is_floating_point:
+        return dtype
+    return default
+
+
+def infer_complex_dtype(tensor: Any, default: torch.dtype = torch.complex128) -> torch.dtype:
+    """
+    Infer the complex ``torch`` dtype matching the precision of ``tensor``.
+
+    Complex inputs keep their precision, floating inputs map to their complex
+    counterpart (e.g. ``float32 -> complex64``), and other inputs fall back to
+    ``default``.
+
+    :param tensor: Tensor (torch, numpy, ...) whose precision is inspected.
+    :param default: Dtype returned for non-floating/non-complex inputs.
+    :return: A complex ``torch.dtype``.
+    """
+    dtype = _torch_dtype_of(tensor)
+    if dtype in COMPLEX_TO_REAL_DTYPE:
+        return dtype
+    if dtype in REAL_TO_COMPLEX_DTYPE:
+        return REAL_TO_COMPLEX_DTYPE[dtype]
+    return default
+
+
+def torch_dtype_name(dtype: torch.dtype) -> str:
+    """Return the bare name of a ``torch`` dtype, e.g. ``torch.float32 -> "float32"``."""
+    return str(dtype).rsplit(".", 1)[-1]
+
+
 def to_tensor(
     x: Any, dtype: Optional[torch.dtype] = torch.float64, device: Optional[torch.device] = None
 ) -> Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor, ...], Dict[str, torch.Tensor]]:

--- a/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
+++ b/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
@@ -204,6 +204,66 @@ class TestExtendedCovarianceMatrix:
         np.testing.assert_allclose(tilde + tilde.T, 0.0, atol=ATOL)
 
 
+class TestMPfaffianPrecisionControl:
+    """The m-Pfaffian building blocks must preserve input precision, not force float64."""
+
+    @pytest.mark.parametrize(
+        "amp_dtype, expected_real_dtype",
+        [(torch.complex64, torch.float32), (torch.complex128, torch.float64)],
+    )
+    def test_displacement_vector_precision(self, amp_dtype, expected_real_dtype):
+        psi = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=amp_dtype)
+        d = displacement_vector(psi, [0, 1])
+        assert d.dtype == expected_real_dtype
+
+    @pytest.mark.parametrize("r_dtype", [torch.float32, torch.float64])
+    def test_extended_covariance_matrix_precision(self, r_dtype):
+        n = 2
+        cov = torch.zeros(2 * n, 2 * n, dtype=r_dtype)
+        d = torch.zeros(2 * n, dtype=r_dtype)
+        tilde = extended_covariance_matrix(cov, d)
+        assert tilde.dtype == r_dtype
+
+    @pytest.mark.parametrize(
+        "r_dtype, c_dtype",
+        [(torch.float32, torch.complex64), (torch.float64, torch.complex128)],
+    )
+    def test_end_to_end_device_precision(self, r_dtype, c_dtype):
+        """Device r_dtype/c_dtype must control the whole expval pipeline dtype."""
+        inv = 1 / np.sqrt(2)
+        dev = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype, c_dtype=c_dtype)
+        amps = torch.tensor([[1.0, 0.0], [inv, inv]], dtype=c_dtype)
+        params = torch.tensor([0.3, 0.4], dtype=r_dtype)
+
+        @qml.qnode(dev)
+        def circ(p):
+            ProductState(amps, wires=[0, 1])
+            CompRyRy(p, wires=[0, 1])
+            return qml.expval(qml.Z(0) @ qml.X(1))
+
+        res = circ(params)
+        assert dev.extended_covariance_matrix.dtype == r_dtype
+        assert res.dtype == r_dtype
+
+    def test_precision_values_agree_across_dtypes(self):
+        """float32 and float64 pipelines must agree to single precision."""
+        inv = 1 / np.sqrt(2)
+        vals = {}
+        for r_dtype, c_dtype in [(torch.float32, torch.complex64), (torch.float64, torch.complex128)]:
+            dev = NonInteractingFermionicDevice(wires=2, r_dtype=r_dtype, c_dtype=c_dtype)
+            amps = torch.tensor([[1.0, 0.0], [inv, inv]], dtype=c_dtype)
+            params = torch.tensor([0.3, 0.4], dtype=r_dtype)
+
+            @qml.qnode(dev)
+            def circ(p):
+                ProductState(amps, wires=[0, 1])
+                CompRyRy(p, wires=[0, 1])
+                return qml.expval(qml.Z(0) @ qml.X(1))
+
+            vals[r_dtype] = float(circ(params))
+        np.testing.assert_allclose(vals[torch.float32], vals[torch.float64], atol=1e-5)
+
+
 class TestSignedPfaffian:
     """Tests for the signed_pfaffian implementation via Parlett-Reid skew-tridiagonalization."""
 

--- a/tests/test_operations/test_state_preparation/test_product_state.py
+++ b/tests/test_operations/test_state_preparation/test_product_state.py
@@ -104,6 +104,26 @@ class TestProductState:
         cov_matrix = ProductState(matrix, wires=[0, 1, 2]).covariance_matrix
         torch.testing.assert_close(cov_flat, cov_matrix)
 
+    @pytest.mark.parametrize(
+        "amp_dtype, expected_real_dtype",
+        [
+            (torch.complex64, torch.float32),
+            (torch.complex128, torch.float64),
+            (torch.float32, torch.float32),
+            (torch.float64, torch.float64),
+        ],
+    )
+    def test_covariance_matrix_preserves_input_precision(self, amp_dtype, expected_real_dtype):
+        inv = 1 / np.sqrt(2)
+        amps = torch.tensor([[1.0, 0.0], [inv, inv]], dtype=amp_dtype)
+        cov = ProductState(amps, wires=[0, 1]).covariance_matrix
+        assert cov.dtype == expected_real_dtype
+
+    def test_init_preserves_complex64_amplitudes(self):
+        amps = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+        op = ProductState(amps, wires=[0, 1])
+        assert op.data[0].dtype == torch.complex64
+
     def test_state_vector_matches_explicit_kron(self):
         n = 3
         # |+> on q0, |1> on q1, (|0>+i|1>)/sqrt(2) on q2

--- a/tests/test_utils/test_pfaffian.py
+++ b/tests/test_utils/test_pfaffian.py
@@ -11,6 +11,7 @@ from torch.autograd import gradcheck
 from matchcake import utils
 from matchcake.utils._pfaffian import (
     _pfaffian_fdbpf_lock,
+    infer_real_dtype,
     sector_pfaffian_features,
     signed_pfaffian,
 )
@@ -175,6 +176,50 @@ class TestPfaffianExtended:
         expected = a * f - b * e + c * d
         pf = float(signed_pfaffian(A))
         np.testing.assert_allclose(pf, expected, atol=1e-10)
+
+    @pytest.mark.parametrize(
+        "in_dtype, expected_real_dtype",
+        [
+            (torch.float32, torch.float32),
+            (torch.float64, torch.float64),
+            (torch.complex64, torch.float32),
+            (torch.complex128, torch.float64),
+        ],
+    )
+    def test_infer_real_dtype_torch(self, in_dtype, expected_real_dtype):
+        assert infer_real_dtype(torch.zeros(2, 2, dtype=in_dtype)) == expected_real_dtype
+
+    def test_infer_real_dtype_integer_fallback(self):
+        assert infer_real_dtype(torch.zeros(2, 2, dtype=torch.int64)) == torch.float64
+
+    def test_infer_real_dtype_numpy(self):
+        assert infer_real_dtype(np.zeros((2, 2), dtype=np.float32)) == torch.float32
+        assert infer_real_dtype(np.zeros((2, 2), dtype=np.complex128)) == torch.float64
+
+    @pytest.mark.parametrize("submatrix_size", [2, 4])
+    def test_sector_pfaffian_preserves_input_precision(self, submatrix_size):
+        # float32 input must not be silently upcast to float64 internals.
+        m = torch.randn(submatrix_size, submatrix_size, dtype=torch.float32)
+        A = m - m.T
+        index_sets = np.array([list(range(submatrix_size))])
+        result = sector_pfaffian_features(A, index_sets)
+        assert result.dtype == torch.float32
+
+    @pytest.mark.parametrize("submatrix_size", [2, 4])
+    def test_sector_pfaffian_explicit_dtype_override(self, submatrix_size):
+        m = torch.randn(submatrix_size, submatrix_size, dtype=torch.float32)
+        A = m - m.T
+        index_sets = np.array([list(range(submatrix_size))])
+        result = sector_pfaffian_features(A, index_sets, dtype=torch.float64)
+        assert result.dtype == torch.float32  # output recast to input dtype
+        # Value matches the float64 reference within float32 tolerance.
+        ref = sector_pfaffian_features(A.to(torch.float64), index_sets)
+        np.testing.assert_allclose(result.numpy(), ref.numpy(), atol=1e-5, rtol=1e-4)
+
+    def test_signed_pfaffian_preserves_float32(self):
+        m = torch.randn(4, 4, dtype=torch.float32)
+        A = m - m.T
+        assert signed_pfaffian(A).dtype == torch.float32
 
     def test_signed_pfaffian_pivot_swap_triggered(self):
         # Construct a matrix where M[3,0] > M[1,0] to force pivot swap.

--- a/tests/test_utils/test_torch_utils.py
+++ b/tests/test_utils/test_torch_utils.py
@@ -4,9 +4,58 @@ import numpy as np
 import pytest
 import torch
 
-from matchcake.utils.torch_utils import detach, to_numpy, to_tensor, torch_wrap_circular_bounds
+from matchcake.utils.torch_utils import (
+    detach,
+    infer_complex_dtype,
+    infer_real_dtype,
+    to_numpy,
+    to_tensor,
+    torch_dtype_name,
+    torch_wrap_circular_bounds,
+)
 
 from ..configs import ATOL_SCALAR_COMPARISON, RTOL_SCALAR_COMPARISON, TEST_SEED, set_seed
+
+
+class TestDtypeInference:
+    @pytest.mark.parametrize(
+        "in_dtype, expected",
+        [
+            (torch.float32, torch.float32),
+            (torch.float64, torch.float64),
+            (torch.complex64, torch.float32),
+            (torch.complex128, torch.float64),
+        ],
+    )
+    def test_infer_real_dtype_torch(self, in_dtype, expected):
+        assert infer_real_dtype(torch.zeros(2, dtype=in_dtype)) == expected
+
+    @pytest.mark.parametrize(
+        "in_dtype, expected",
+        [
+            (torch.float32, torch.complex64),
+            (torch.float64, torch.complex128),
+            (torch.complex64, torch.complex64),
+            (torch.complex128, torch.complex128),
+        ],
+    )
+    def test_infer_complex_dtype_torch(self, in_dtype, expected):
+        assert infer_complex_dtype(torch.zeros(2, dtype=in_dtype)) == expected
+
+    def test_infer_real_dtype_integer_uses_default(self):
+        assert infer_real_dtype(torch.zeros(2, dtype=torch.int64)) == torch.float64
+        assert infer_real_dtype(torch.zeros(2, dtype=torch.int64), default=torch.float32) == torch.float32
+
+    def test_infer_complex_dtype_integer_uses_default(self):
+        assert infer_complex_dtype(torch.zeros(2, dtype=torch.int64)) == torch.complex128
+
+    def test_infer_dtype_numpy(self):
+        assert infer_real_dtype(np.zeros(2, dtype=np.float32)) == torch.float32
+        assert infer_complex_dtype(np.zeros(2, dtype=np.complex128)) == torch.complex128
+
+    def test_torch_dtype_name(self):
+        assert torch_dtype_name(torch.float32) == "float32"
+        assert torch_dtype_name(torch.complex128) == "complex128"
 
 
 class TestToTensor:


### PR DESCRIPTION
# Description

This pull request introduces comprehensive precision control throughout the m-Pfaffian expectation value pipeline, ensuring that user-supplied floating-point and complex precisions (e.g., float32/complex64) are preserved instead of being silently upcast to float64/complex128. This is achieved by inferring the appropriate real or complex torch dtype at every stage, propagating it through all relevant computations, and updating tests to verify this behavior. The changes improve both memory efficiency and user control over numerical precision.

Key changes include:

**Precision Control and Inference:**

* Added `infer_real_dtype`, `infer_complex_dtype`, and `torch_dtype_name` utilities in `torch_utils.py` to infer and propagate the correct torch dtype based on input tensors, with mappings between real and complex types. (`[src/matchcake/utils/torch_utils.pyR35-R93](diffhunk://#diff-e0bc40a63320f04f1f12fa221a75234702d073f838bc6aa30c9d01de9c8758b5R35-R93)`)
* Updated all m-Pfaffian building blocks (`displacement_vector`, `extended_covariance_matrix`, `sptm_lift`, and related functions in `_extended_covariance.py` and `_pfaffian.py`) to use inferred dtypes instead of hardcoded float64/complex128. (`[[1]](diffhunk://#diff-db4e6db383f1b9532fce62d48de42c0ffb0eefb037aa2864084d3664dff6923fR29-R37)`, `[[2]](diffhunk://#diff-db4e6db383f1b9532fce62d48de42c0ffb0eefb037aa2864084d3664dff6923fL48-R61)`, `[[3]](diffhunk://#diff-db4e6db383f1b9532fce62d48de42c0ffb0eefb037aa2864084d3664dff6923fL77-R92)`, `[[4]](diffhunk://#diff-db4e6db383f1b9532fce62d48de42c0ffb0eefb037aa2864084d3664dff6923fL107-R120)`, `[[5]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R13-R16)`, `[[6]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R25-R35)`, `[[7]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R89-R105)`)

**ProductState and Device Integration:**

* Modified `ProductState` initialization and covariance matrix computation to preserve input precision and ensure consistent dtype propagation, including casting and internal conversion logic. (`[[1]](diffhunk://#diff-b46b465805b9b9ff68efb9debe5ac0df93d60df68f04a3d03a376dad85b26861L119-R126)`, `[[2]](diffhunk://#diff-b46b465805b9b9ff68efb9debe5ac0df93d60df68f04a3d03a376dad85b26861L184-R197)`, `[[3]](diffhunk://#diff-b46b465805b9b9ff68efb9debe5ac0df93d60df68f04a3d03a376dad85b26861L308-R326)`)
* Updated `NonInteractingFermionicDevice` to cast initial amplitudes and covariance matrices to the device's configured precision, enforcing global dtype control. (`[src/matchcake/devices/nif_device.pyL1161-R1164](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L1161-R1164)`)

**Pfaffian Utilities:**

* Updated `signed_pfaffian` and `sector_pfaffian_features` to accept an optional `dtype` argument and default to inferring precision from inputs, avoiding unnecessary upcasting. (`[[1]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R13-R16)`, `[[2]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R25-R35)`, `[[3]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R89-R105)`)

**Testing and Validation:**

* Added extensive new tests to verify that all m-Pfaffian components and the overall device pipeline preserve and respect user-specified precisions, and that results agree across float32/float64 to single precision. (`[[1]](diffhunk://#diff-6f39734b19b474fdd0083d57d034bd12d07889b4af94d6999cb81fd323b985f5R207-R266)`, `[[2]](diffhunk://#diff-6ab800e03f93e899c6bf5082650755f51babc3abbedd0c35801f283fc233b169R107-R126)`)
* Updated imports and test utilities to support new precision inference logic. (`[[1]](diffhunk://#diff-80a8b5073db17e428fc0c8ea2044aec9a32055397822f57f36ffc7ec54d34770L12-R12)`, `[[2]](diffhunk://#diff-80a8b5073db17e428fc0c8ea2044aec9a32055397822f57f36ffc7ec54d34770R104-R118)`, `[[3]](diffhunk://#diff-218989875e2fa3e92cc4b677be41884bdb3446825b7637efaa90ef4dbf685e27R14)`)

These changes collectively ensure that precision is user-controllable and consistent across the entire m-Pfaffian workflow, improving both correctness and efficiency.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
