### PR TITLE
Add support for custom data types in fermionic kernel classes

### DIFF
--- a/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
+++ b/src/matchcake/ml/kernels/fermionic_pqc_kernel.py
@@ -90,6 +90,8 @@ class FermionicPQCKernel(NIFKernel):
         alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
         alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
         n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
+        r_dtype: Optional[torch.dtype] = None,
+        c_dtype: Optional[torch.dtype] = None,
         rotations: str = DEFAULT_ROTATIONS,
         entangling_mth: str = DEFAULT_ENTANGLING_MTH,
     ):
@@ -108,6 +110,8 @@ class FermionicPQCKernel(NIFKernel):
         :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel
             alignment optimization, used for early stopping criteria.
         :param n_qubits: Number of qubits to be used in the quantum circuit.
+        :param r_dtype: The real floating-point dtype passed to the non-interacting fermionic device.
+        :param c_dtype: The complex dtype passed to the non-interacting fermionic device.
         :param rotations: Types of rotations to be applied in the quantum circuit, specified
             as a comma-separated string (e.g., "Y,Z").
         :param entangling_mth: Method for entangling qubits in the quantum circuit. Must
@@ -122,6 +126,8 @@ class FermionicPQCKernel(NIFKernel):
             alignment_early_stopping_patience=alignment_early_stopping_patience,
             alignment_early_stopping_threshold=alignment_early_stopping_threshold,
             n_qubits=n_qubits,
+            r_dtype=r_dtype,
+            c_dtype=c_dtype,
         )
         self.rotations = rotations
         self.entangling_mth = entangling_mth

--- a/src/matchcake/ml/kernels/linear_nif_kernel.py
+++ b/src/matchcake/ml/kernels/linear_nif_kernel.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import numpy as np
 import torch
 
@@ -41,6 +43,8 @@ class LinearNIFKernel(NIFKernel):
         alignment_early_stopping_patience: int = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
         alignment_early_stopping_threshold: float = NIFKernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
         n_qubits: int = NIFKernel.DEFAULT_N_QUBITS,
+        r_dtype: Optional[torch.dtype] = None,
+        c_dtype: Optional[torch.dtype] = None,
         bias: bool = DEFAULT_BIAS,
         encoder_activation: str = DEFAULT_ENCODER_ACTIVATION,
     ):
@@ -69,6 +73,10 @@ class LinearNIFKernel(NIFKernel):
         :type alignment_early_stopping_threshold: float
         :param n_qubits: Number of qubits used in the quantum computation process.
         :type n_qubits: int
+        :param r_dtype: The real floating-point dtype passed to the non-interacting fermionic device.
+        :type r_dtype: Optional[torch.dtype]
+        :param c_dtype: The complex dtype passed to the non-interacting fermionic device.
+        :type c_dtype: Optional[torch.dtype]
         :param bias: Determines if the linear layers in the encoder should include a
             bias term.
         :type bias: bool
@@ -85,6 +93,8 @@ class LinearNIFKernel(NIFKernel):
             alignment_early_stopping_patience=alignment_early_stopping_patience,
             alignment_early_stopping_threshold=alignment_early_stopping_threshold,
             n_qubits=n_qubits,
+            r_dtype=r_dtype,
+            c_dtype=c_dtype,
         )
         self._bias = bias
         self._encoder_activation = encoder_activation
@@ -122,7 +132,7 @@ class LinearNIFKernel(NIFKernel):
 
     @n_qubits.setter
     def n_qubits(self, value: int):
-        self._q_device = NonInteractingFermionicDevice(value, r_dtype=self.R_DTYPE)
+        self._q_device = NonInteractingFermionicDevice(value, r_dtype=self._r_dtype, c_dtype=self._c_dtype)
         self.encoder[1] = torch.nn.LazyLinear(self.encoder_out_indices[0].size, bias=self.bias, dtype=self.R_DTYPE)
 
     @property

--- a/src/matchcake/ml/kernels/nif_kernel.py
+++ b/src/matchcake/ml/kernels/nif_kernel.py
@@ -244,6 +244,14 @@ class NIFKernel(Kernel):
         return self._q_device
 
     @property
+    def r_dtype(self) -> torch.dtype:
+        return self._r_dtype
+
+    @property
+    def c_dtype(self) -> torch.dtype:
+        return self._c_dtype
+
+    @property
     def R_DTYPE(self) -> torch.dtype:
         return getattr(self._q_device, "R_DTYPE", self._r_dtype)
 

--- a/src/matchcake/ml/kernels/nif_kernel.py
+++ b/src/matchcake/ml/kernels/nif_kernel.py
@@ -9,7 +9,7 @@ from tqdm import tqdm
 from ...devices.nif_device import NonInteractingFermionicDevice
 from ...operations import SingleParticleTransitionMatrixOperation
 from ...typing import TensorLike
-from ...utils.torch_utils import to_tensor
+from ...utils.torch_utils import get_torch_dtype, to_tensor
 from .gram_matrix import GramMatrix
 from .kernel import Kernel
 
@@ -25,11 +25,16 @@ class NIFKernel(Kernel):
     The class supports flexible configuration of qubit numbers and processing batch
     sizes.
 
-    :ivar R_DTYPE: Data type used for computation within the kernel.
+    :ivar R_DTYPE: Real floating-point dtype used by the underlying device. Read from the device so
+        the device remains the single source of truth for precision.
     :type R_DTYPE: torch.dtype
+    :ivar C_DTYPE: Complex dtype used by the underlying device.
+    :type C_DTYPE: torch.dtype
     """
 
     DEFAULT_N_QUBITS = 12
+    DEFAULT_R_DTYPE = torch.float32
+    DEFAULT_C_DTYPE = torch.complex64
 
     def __init__(
         self,
@@ -42,6 +47,8 @@ class NIFKernel(Kernel):
         alignment_early_stopping_patience: int = Kernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_PATIENCE,
         alignment_early_stopping_threshold: float = Kernel.DEFAULT_ALIGNMENT_EARLY_STOPPING_THRESHOLD,
         n_qubits: int = DEFAULT_N_QUBITS,
+        r_dtype: Optional[torch.dtype] = None,
+        c_dtype: Optional[torch.dtype] = None,
     ):
         """
         Initializes the class with specific parameters for quantum device configuration and
@@ -57,6 +64,10 @@ class NIFKernel(Kernel):
         :param alignment_early_stopping_threshold: The threshold for determining improvement in kernel
             alignment optimization, used for early stopping criteria.
         :param n_qubits: The number of qubits for the non-interacting fermionic device.
+        :param r_dtype: The real floating-point dtype passed to the non-interacting fermionic device.
+            Defaults to :attr:`DEFAULT_R_DTYPE` when ``None``.
+        :param c_dtype: The complex dtype passed to the non-interacting fermionic device.
+            Defaults to :attr:`DEFAULT_C_DTYPE` when ``None``.
         """
         super().__init__(
             gram_batch_size=gram_batch_size,
@@ -67,8 +78,9 @@ class NIFKernel(Kernel):
             alignment_early_stopping_patience=alignment_early_stopping_patience,
             alignment_early_stopping_threshold=alignment_early_stopping_threshold,
         )
-        self.R_DTYPE = torch.float32
-        self._q_device = NonInteractingFermionicDevice(n_qubits, r_dtype=self.R_DTYPE)
+        self._r_dtype = get_torch_dtype(r_dtype, self.DEFAULT_R_DTYPE)
+        self._c_dtype = get_torch_dtype(c_dtype, self.DEFAULT_C_DTYPE)
+        self._q_device = NonInteractingFermionicDevice(n_qubits, r_dtype=self._r_dtype, c_dtype=self._c_dtype)
 
     def forward(self, x0: TensorLike, x1: Optional[TensorLike] = None, **kwargs) -> torch.Tensor:
         """
@@ -225,11 +237,19 @@ class NIFKernel(Kernel):
         :param value: The number of qubits to be set for the quantum device.
         :type value: int
         """
-        self._q_device = NonInteractingFermionicDevice(value, r_dtype=self.R_DTYPE)
+        self._q_device = NonInteractingFermionicDevice(value, r_dtype=self._r_dtype, c_dtype=self._c_dtype)
 
     @property
     def q_device(self):
         return self._q_device
+
+    @property
+    def R_DTYPE(self) -> torch.dtype:
+        return getattr(self._q_device, "R_DTYPE", self._r_dtype)
+
+    @property
+    def C_DTYPE(self) -> torch.dtype:
+        return getattr(self._q_device, "C_DTYPE", self._c_dtype)
 
     @cached_property
     def sptms_train(self) -> TensorLike:

--- a/tests/test_ml/test_kernels/test_fermionic_pqc_kernel.py
+++ b/tests/test_ml/test_kernels/test_fermionic_pqc_kernel.py
@@ -32,6 +32,19 @@ class TestFermionicPQCKernel:
         instance = FermionicPQCKernel(n_qubits=n_qubits, rotations=rotations, entangling_mth=entangling_mth)
         return instance
 
+    def test_custom_dtypes_propagate_to_device(self, n_qubits, rotations, entangling_mth):
+        kernel = FermionicPQCKernel(
+            n_qubits=n_qubits,
+            rotations=rotations,
+            entangling_mth=entangling_mth,
+            r_dtype=torch.float64,
+            c_dtype=torch.complex128,
+        )
+        assert kernel.R_DTYPE == torch.float64
+        assert kernel.C_DTYPE == torch.complex128
+        assert kernel.q_device.R_DTYPE == torch.float64
+        assert kernel.q_device.C_DTYPE == torch.complex128
+
     @pytest.fixture
     def x_train(self):
         return np.linspace(0.0, 1.0, num=80).reshape(10, 8)

--- a/tests/test_ml/test_kernels/test_linear_nif_kernel.py
+++ b/tests/test_ml/test_kernels/test_linear_nif_kernel.py
@@ -19,6 +19,22 @@ class TestLinearNIFKernel:
     def x_train(self):
         return np.linspace(0.0, 0.05, num=80).reshape(10, 8)
 
+    def test_custom_dtypes_propagate_to_device(self, n_qubits, encoder_activation, bias):
+        kernel = LinearNIFKernel(
+            n_qubits=n_qubits,
+            bias=bias,
+            encoder_activation=encoder_activation,
+            r_dtype=torch.float64,
+            c_dtype=torch.complex128,
+        )
+        assert kernel.R_DTYPE == torch.float64
+        assert kernel.C_DTYPE == torch.complex128
+        assert kernel.q_device.R_DTYPE == torch.float64
+        assert kernel.q_device.C_DTYPE == torch.complex128
+        kernel.n_qubits = n_qubits + 1
+        assert kernel.q_device.R_DTYPE == torch.float64
+        assert kernel.q_device.C_DTYPE == torch.complex128
+
     def test_fit(self, kernel_instance, x_train):
         kernel_instance.fit(x_train)
         assert kernel_instance.x_train_ is x_train

--- a/tests/test_ml/test_kernels/test_nif_kernel.py
+++ b/tests/test_ml/test_kernels/test_nif_kernel.py
@@ -30,6 +30,33 @@ class TestNIFKernel:
         assert kernel_instance.gram_batch_size == 10_000
         assert isinstance(kernel_instance.q_device, NonInteractingFermionicDevice)
 
+    def test_default_dtypes_match_device(self):
+        kernel = NIFKernel()
+        assert kernel.R_DTYPE == NIFKernel.DEFAULT_R_DTYPE
+        assert kernel.C_DTYPE == NIFKernel.DEFAULT_C_DTYPE
+        assert kernel.q_device.R_DTYPE == kernel.R_DTYPE
+        assert kernel.q_device.C_DTYPE == kernel.C_DTYPE
+
+    @pytest.mark.parametrize(
+        "r_dtype, c_dtype",
+        [
+            (torch.float32, torch.complex64),
+            (torch.float64, torch.complex128),
+        ],
+    )
+    def test_custom_dtypes_propagate_to_device(self, r_dtype, c_dtype):
+        kernel = NIFKernel(r_dtype=r_dtype, c_dtype=c_dtype)
+        assert kernel.R_DTYPE == r_dtype
+        assert kernel.C_DTYPE == c_dtype
+        assert kernel.q_device.R_DTYPE == r_dtype
+        assert kernel.q_device.C_DTYPE == c_dtype
+
+    def test_dtypes_preserved_when_setting_n_qubits(self):
+        kernel = NIFKernel(r_dtype=torch.float64, c_dtype=torch.complex128)
+        kernel.n_qubits = 4
+        assert kernel.q_device.R_DTYPE == torch.float64
+        assert kernel.q_device.C_DTYPE == torch.complex128
+
     def test_forward(self, kernel_instance):
         x = torch.rand(10, 10)
         kernel_instance(x)

--- a/tests/test_ml/test_kernels/test_nif_kernel.py
+++ b/tests/test_ml/test_kernels/test_nif_kernel.py
@@ -57,6 +57,16 @@ class TestNIFKernel:
         assert kernel.q_device.R_DTYPE == torch.float64
         assert kernel.q_device.C_DTYPE == torch.complex128
 
+    def test_sklearn_clone_preserves_dtypes(self):
+        from sklearn.base import clone
+
+        kernel = NIFKernel(r_dtype=torch.float64, c_dtype=torch.complex128)
+        assert kernel.get_params()["r_dtype"] == torch.float64
+        assert kernel.get_params()["c_dtype"] == torch.complex128
+        cloned = clone(kernel)
+        assert cloned.R_DTYPE == torch.float64
+        assert cloned.C_DTYPE == torch.complex128
+
     def test_forward(self, kernel_instance):
         x = torch.rand(10, 10)
         kernel_instance(x)


### PR DESCRIPTION
# Description

This pull request introduces support for configurable real and complex data types (`r_dtype` and `c_dtype`) in the NIF-based kernel classes and ensures these types are consistently propagated to the underlying quantum device. The changes also add tests to verify correct dtype propagation and preservation throughout the kernel lifecycle.

**Enhanced dtype configuration and propagation:**

* Added `r_dtype` and `c_dtype` parameters to the constructors of `NIFKernel`, `LinearNIFKernel`, and `FermionicPQCKernel`, allowing users to specify real and complex data types for computations. These are now used when initializing the underlying `NonInteractingFermionicDevice` (`src/matchcake/ml/kernels/nif_kernel.py`, `src/matchcake/ml/kernels/linear_nif_kernel.py`, `src/matchcake/ml/kernels/fermionic_pqc_kernel.py`). [[1]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bR50-R51) [[2]](diffhunk://#diff-18b660fff5eefd8d0d4dc343e877c174a87cdbdab2e183c3154d5605b85770f3R46-R47) [[3]](diffhunk://#diff-d20cb52eb9fec3812574627456b767986438c4f290af66d811d755b16b1e72fdR93-R94)
* Updated docstrings and class variables to document the new dtype parameters and their default values, clarifying their roles and defaulting behavior. [[1]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bL28-R37) [[2]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bR67-R70) [[3]](diffhunk://#diff-18b660fff5eefd8d0d4dc343e877c174a87cdbdab2e183c3154d5605b85770f3R76-R79) [[4]](diffhunk://#diff-d20cb52eb9fec3812574627456b767986438c4f290af66d811d755b16b1e72fdR113-R114)
* Ensured that when the number of qubits is changed after initialization, the custom dtypes are preserved and passed to the new device instance. [[1]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bL228-R253) [[2]](diffhunk://#diff-18b660fff5eefd8d0d4dc343e877c174a87cdbdab2e183c3154d5605b85770f3L125-R135)

**Testing improvements:**

* Added tests for all three kernel classes to verify that custom and default dtypes are correctly propagated to the device and preserved when modifying kernel parameters such as `n_qubits`. [[1]](diffhunk://#diff-41acae12bd4c6a3db078ab7cfb4166dc66aa11f58978dffa3468d8f5d98ef5bfR33-R59) [[2]](diffhunk://#diff-e72321eb99c16433a2ddb34fb36609c5e3981ff1535b72a46e839e5e5c71f758R22-R37) [[3]](diffhunk://#diff-115023174a789681b3814c2c5fd72d3ef321bd840a1e824f635800b7839a4af3R35-R47)

**Internal utility updates:**

* Imported and used `get_torch_dtype` utility to standardize dtype handling and fallback logic. [[1]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bL12-R12) [[2]](diffhunk://#diff-ff363c40f1eb2de47a496c15d5224bacd2934baf75e4eaa9008c780099c3782bL70-R83)

These changes improve flexibility and reproducibility in quantum kernel computations by allowing explicit control over numerical precision.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
