### PR TITLE
Opt mpf

### DIFF
--- a/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
+++ b/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
@@ -1,8 +1,12 @@
-from typing import Any, cast
+import threading
+import weakref
+from collections import OrderedDict
+from typing import Any, Callable, Optional, cast
 
 import numpy as np
 import pennylane as qml
 import torch
+from pennylane import BasisState
 from pennylane.operation import Operator, StatePrepBase, TermsUndefinedError
 from pennylane.pauli import pauli_word_to_string
 
@@ -34,6 +38,189 @@ def extend_majorana_indices(
     return np.concatenate([mu, [parity_index]]), alpha * extra_phase
 
 
+class _DecompositionCache:
+    """Memoizes the Pauli -> Majorana decomposition of an observable.
+
+    Which Majorana index set each term maps to, its sector and its constant phase
+    depend only on the observable's Pauli operators and the device wires -- never
+    on the per-forward covariance matrix. For a fixed circuit/Hamiltonian this is
+    recomputed on every forward pass, which dominates the runtime when the Pfaffian
+    kernel is cheap (e.g. float32 internals). This class memoizes it.
+
+    Both tiers cache only the *coefficient-independent* structure; the coefficients
+    are read live from ``observable.terms()`` on every call (which is cheap and does
+    not rebuild anything) and folded in afterwards. An observable whose coefficients
+    change in place between calls -- even when the same object is reused -- therefore
+    always produces correct values, never a stale cached coefficient.
+
+    Two tiers, both bounded (LRU) and lock-protected:
+      * ``_id_cache``: keyed by ``id(observable)`` and *validated by a weak
+        reference* to the original object. A bare ``id()`` key is unsafe -- once an
+        object is garbage-collected its id can be reused by an unrelated object,
+        which would return a stale (wrong) entry. Checking ``wref() is observable``
+        makes a hit impossible unless the *same live object* is presented again, so
+        id reuse can never produce a false hit. A hit skips both the Pauli-word
+        string construction (the structural key) and the Majorana decomposition.
+      * ``_struct_cache``: keyed structurally by the tuple of Pauli-word strings
+        (relative to the device wire order) plus the wires and matrix size. Correct
+        even when callers pass freshly built observable objects every forward, or
+        reuse a Pauli structure with different coefficients.
+
+    State is held at the class level, so a single cache is shared across all
+    strategy instances within a process. Under multiprocessing ``spawn`` each
+    process gets its own class state, so the caches are never shared across
+    processes; the lock guards concurrent threads.
+    """
+
+    MAXSIZE = 64
+    _lock = threading.Lock()
+    # Both caches map to the same coefficient-independent structure:
+    #   {sector: (index_sets, ext_phases, term_indices, wick_phase)}
+    _struct_cache: "OrderedDict[tuple, dict]" = OrderedDict()  # struct_key -> structure
+    _id_cache: "OrderedDict[int, tuple]" = OrderedDict()  # id(obs) -> (weakref, context_sig, structure)
+
+    @classmethod
+    def clear(cls) -> None:
+        """Empty both cache tiers (primarily for tests)."""
+        with cls._lock:
+            cls._struct_cache.clear()
+            cls._id_cache.clear()
+
+    @classmethod
+    def is_decomposed(cls, observable: Operator) -> bool:
+        """Return True iff ``observable`` has a live entry in the identity cache.
+
+        Validated by weakref identity, so a recycled id can never yield a false
+        positive. A True result means the observable is Pauli-decomposable.
+        """
+        with cls._lock:
+            entry = cls._id_cache.get(id(observable))
+            return entry is not None and entry[0]() is observable
+
+    @staticmethod
+    def _coeff_to_complex(coeff: Any) -> complex:
+        """Pull a Hamiltonian coefficient out as a plain Python complex (severs grad).
+
+        Mirrors the original per-term ``complex(h_coeff.item() if Tensor else h_coeff)``;
+        coefficients are treated as constants exactly as before, so gradients flow only
+        through the covariance matrix.
+        """
+        if isinstance(coeff, torch.Tensor):
+            return complex(coeff.item())
+        return complex(coeff)
+
+    @staticmethod
+    def _build_structure(
+        pauli_strs: tuple,
+        device_wires: list,
+        parity_index: int,
+        n_qubits: int,
+    ) -> dict:
+        """Coefficient-independent decomposition grouped by parity sector.
+
+        Returns ``{sector: (index_sets, ext_phases, term_indices, wick_phase)}`` where
+        ``index_sets`` is ``(n_terms_in_sector, sector)`` int, ``ext_phases`` is the
+        complex phase per term, ``term_indices`` maps back to the Hamiltonian term
+        order, and ``wick_phase = (-1j)**(sector//2)``.
+        """
+        jw = JordanWigner(n_qubits)
+        by_sector: dict[int, tuple[list, list, list]] = {}
+        for term_idx, pauli_str in enumerate(pauli_strs):
+            mu, alpha = jw.pauli_to_majorana(pauli_str, device_wires)
+            ext_index_set, ext_phase = extend_majorana_indices(mu, alpha, parity_index)
+            sector = len(ext_index_set)
+            idx_list, phase_list, term_list = by_sector.setdefault(sector, ([], [], []))
+            idx_list.append(ext_index_set)
+            phase_list.append(ext_phase)
+            term_list.append(term_idx)
+
+        structure: dict[int, tuple] = {}
+        for sector, (idx_list, phase_list, term_list) in by_sector.items():
+            index_sets = np.stack(idx_list)  # (n_terms, sector); (n_terms, 0) for sector 0
+            ext_phases = np.asarray(phase_list, dtype=complex)
+            term_indices = np.asarray(term_list, dtype=int)
+            wick_phase = (-1j) ** (sector // 2)
+            structure[sector] = (index_sets, ext_phases, term_indices, wick_phase)
+        return structure
+
+    @classmethod
+    def _build_payload(cls, structure: dict, h_coeffs: Any) -> "OrderedDict[int, tuple]":
+        """Bake the (constant) coefficients into per-sector ``scalar_coeffs``.
+
+        ``scalar_coeffs[k] = Re(coeff_k * ext_phase_k * wick_phase)`` -- exactly the
+        real scalar the original per-term loop computed, just vectorized.
+        """
+        payload: "OrderedDict[int, tuple]" = OrderedDict()
+        for sector, (index_sets, ext_phases, term_indices, wick_phase) in structure.items():
+            coeffs = np.asarray([cls._coeff_to_complex(h_coeffs[int(t)]) for t in term_indices], dtype=complex)
+            scalar_coeffs = np.real(coeffs * ext_phases * wick_phase).astype(np.float64)
+            payload[sector] = (index_sets, scalar_coeffs)
+        return payload
+
+    @classmethod
+    def get_payload(
+        cls,
+        observable: Operator,
+        terms_of: Callable[[Operator], tuple],
+        device_wires_tuple: tuple,
+        n_total: int,
+    ) -> "OrderedDict[int, tuple]":
+        """Return ``{sector: (index_sets, scalar_coeffs)}`` for this observable.
+
+        The coefficient-independent structure is taken from the weakref-validated
+        identity cache, then the structural cache, and only falls through to the full
+        Pauli -> Majorana decomposition on a miss. Coefficients are read live from
+        ``terms_of`` on every call (cheap) and folded in last, so a reused object
+        whose coefficients change in place never yields a stale value.
+        """
+        parity_index = n_total - 1
+        n_qubits = parity_index // 2
+        oid = id(observable)
+        context_sig = (device_wires_tuple, n_total)
+
+        h_coeffs, h_ops = terms_of(observable)
+
+        structure = None
+        with cls._lock:
+            entry = cls._id_cache.get(oid)
+            if entry is not None:
+                wref, sig, cached_structure = entry
+                if sig == context_sig and wref() is observable:
+                    cls._id_cache.move_to_end(oid)
+                    structure = cached_structure
+
+        if structure is None:
+            device_wires = list(device_wires_tuple)
+            wire_map = {w: i for i, w in enumerate(device_wires)}
+            pauli_strs = tuple(pauli_word_to_string(op, wire_map=wire_map) for op in h_ops)
+            struct_key = (pauli_strs, device_wires_tuple, n_total)
+
+            with cls._lock:
+                structure = cls._struct_cache.get(struct_key)
+                if structure is not None:
+                    cls._struct_cache.move_to_end(struct_key)
+            if structure is None:
+                structure = cls._build_structure(pauli_strs, device_wires, parity_index, n_qubits)
+                with cls._lock:
+                    cls._struct_cache[struct_key] = structure
+                    cls._struct_cache.move_to_end(struct_key)
+                    while len(cls._struct_cache) > cls.MAXSIZE:
+                        cls._struct_cache.popitem(last=False)
+
+            try:
+                wref = weakref.ref(observable)
+            except TypeError:
+                wref = None
+            if wref is not None:
+                with cls._lock:
+                    cls._id_cache[oid] = (wref, context_sig, structure)
+                    cls._id_cache.move_to_end(oid)
+                    while len(cls._id_cache) > cls.MAXSIZE:
+                        cls._id_cache.popitem(last=False)
+
+        return cls._build_payload(structure, h_coeffs)
+
+
 class MPfaffianExpvalStrategy(ExpvalStrategy):
     """Compute <P> for arbitrary Pauli observables via the extended-encoding m-Pfaffian.
 
@@ -53,6 +240,12 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
 
         <P> = Re( coeff * ext_phase * (-i)^{|ext_index_set|/2} * Pf(ext_cov_matrix|_{ext_index_set}) )
 
+    The Pauli -> Majorana decomposition (index sets, sectors, phases) is a pure
+    function of the observable's Pauli operators and the device wires, so it is
+    memoized (see :class:`_DecompositionCache`); each forward pass folds in the live
+    coefficients and re-evaluates only the Pfaffian math against the current
+    covariance matrix.
+
     Mid-circuit gates must all be matchgates (matchgate evolution preserves the
     lift's identity-block structure on the parity index). This is a device-level
     invariant enforced upstream.
@@ -61,12 +254,18 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
     NAME = "MPfaffianExpvalStrategy"
 
     @staticmethod
-    def _to_hamiltonian(observable: Operator) -> qml.Hamiltonian:
+    def _terms_of(observable: Operator) -> tuple:
+        """Return ``(coeffs, ops)`` for the observable as a sum of Pauli terms.
+
+        Uses ``observable.terms()`` directly (which does not rebuild anything),
+        falling back to a trivial single-term wrapping for operators that do not
+        define a terms decomposition. Reading the coefficients here every call is
+        what keeps the cache correct under in-place coefficient changes.
+        """
         try:
-            terms = observable.terms()
+            return observable.terms()
         except TermsUndefinedError:
-            terms = (torch.ones(1),), [observable]
-        return qml.Hamiltonian(*terms)
+            return (torch.ones(1),), [observable]
 
     def __call__(
         self,
@@ -82,51 +281,27 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
 
         ext_cov_matrix = cast(np.ndarray, extended_covariance_matrix)  # (..., 2n+1, 2n+1)
         n_total = ext_cov_matrix.shape[-1]  # 2n + 1
-        parity_index = n_total - 1  # 2n
+        device_wires_tuple = tuple(sorted(state_prep_op.wires.tolist()))
 
-        hamiltonian = self._to_hamiltonian(observable)
-        h_coeffs, h_ops = hamiltonian.terms()
-
-        device_wires = sorted(state_prep_op.wires.tolist())
-        n_qubits = parity_index // 2
-        jw = JordanWigner(n_qubits)
-
-        global_wire_map = {w: i for i, w in enumerate(device_wires)}
-
-        terms_by_sector: dict[int, list[tuple[np.ndarray, complex, int]]] = {}
-        for term_idx, (coeff, op) in enumerate(zip(h_coeffs, h_ops)):
-            pauli_str = pauli_word_to_string(op, wire_map=global_wire_map)
-            mu, alpha = jw.pauli_to_majorana(pauli_str, device_wires)
-            ext_index_set, ext_phase = extend_majorana_indices(mu, alpha, parity_index)
-            sector = len(ext_index_set)
-            terms_by_sector.setdefault(sector, []).append((ext_index_set, ext_phase, term_idx))
+        payload = _DecompositionCache.get_payload(observable, self._terms_of, device_wires_tuple, n_total)
 
         r_dtype = infer_real_dtype(ext_cov_matrix)
-        pf_values: dict[int, TensorLike] = {}
-        for sector, items in terms_by_sector.items():
-            index_sets = np.stack([item[0] for item in items])  # (n_terms, sector)
+        ext_cov_matrix_t: Optional[TensorLike] = None  # lazily built for the sector-2 read
+        total_re: Any = np.float64(0.0)
+        for sector, (index_sets, scalar_coeffs) in payload.items():
             if sector == 0:
-                pf_values[sector] = torch.ones(len(items), dtype=r_dtype)
+                pf_values = torch.ones(len(scalar_coeffs), dtype=r_dtype)
             elif sector == 2:
+                if ext_cov_matrix_t is None:
+                    ext_cov_matrix_t = torch.as_tensor(qml.math.real(ext_cov_matrix), dtype=r_dtype)
                 i_idx = index_sets[:, 0]
                 j_idx = index_sets[:, 1]
-                ext_cov_matrix_t = torch.as_tensor(qml.math.real(ext_cov_matrix), dtype=r_dtype)
-                pf_values[sector] = ext_cov_matrix_t[..., i_idx, j_idx]  # (..., n_terms)
+                pf_values = ext_cov_matrix_t[..., i_idx, j_idx]  # (..., n_terms)
             else:
-                pf_values[sector] = sector_pfaffian_features(
-                    ext_cov_matrix, index_sets, dtype=r_dtype
-                )  # (..., n_terms)
+                pf_values = sector_pfaffian_features(ext_cov_matrix, index_sets, dtype=r_dtype)  # (..., n_terms)
 
-        total_re: Any = np.float64(0.0)
-        for sector, items in terms_by_sector.items():
-            wick_phase = (-1j) ** (sector // 2)
-            pfs = cast(np.ndarray, pf_values[sector])  # (..., n_terms)
-            for k, (ext_index_set, ext_phase, term_idx) in enumerate(items):
-                h_coeff = h_coeffs[term_idx]
-                coeff = complex(h_coeff.item() if isinstance(h_coeff, torch.Tensor) else h_coeff)
-                pf_k = pfs[..., k]  # (...)
-                scalar = float(np.real(coeff * complex(ext_phase) * wick_phase))
-                total_re = total_re + scalar * pf_k
+            scalar_coeffs_t = torch.as_tensor(scalar_coeffs, dtype=pf_values.dtype, device=pf_values.device)
+            total_re = total_re + pf_values @ scalar_coeffs_t  # (...)
 
         return convert_and_cast_like(total_re, extended_covariance_matrix)
 
@@ -141,13 +316,14 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
           1. state_prep_op is a BasisState or a ProductState.
           2. observable decomposes into a sum of Pauli strings.
         """
-        from pennylane import BasisState
-
         if not isinstance(state_prep_op, (BasisState, ProductState)):
             return False
+        # Fast path: an observable already decomposed (and cached) is, by
+        # construction, Pauli-decomposable.
+        if _DecompositionCache.is_decomposed(observable):
+            return True
         try:
-            hamiltonian = self._to_hamiltonian(observable)
-            _, ops = hamiltonian.terms()
+            _, ops = self._terms_of(observable)
             for op in ops:
                 _ = pauli_word_to_string(op, wire_map={w: i for i, w in enumerate(op.wires)})
         except Exception:

--- a/src/matchcake/operations/state_preparation/state_prep_from_gates.py
+++ b/src/matchcake/operations/state_preparation/state_prep_from_gates.py
@@ -4,13 +4,28 @@ from typing import Any, Callable, Iterator, List, Optional
 import numpy as np
 import pennylane as qml
 from pennylane import BasisState, X
-from pennylane.operation import Operation, StatePrepBase
-from pennylane.wires import WiresLike
+from pennylane.operation import Operation
+from pennylane.wires import Wires, WiresLike
 
 from matchcake.typing import TensorLike
 
+from .product_state import ProductState
 
-class StatePrepFromGates(StatePrepBase):
+
+class StatePrepFromGates(ProductState):
+    r"""Prepare a state by listing the gates that build it from :math:`|0\ldots0\rangle`.
+
+    This is a :class:`ProductState` whose per-qubit amplitudes are obtained by
+    applying the gates yielded by ``gate_generator`` to the all-zero state. Only
+    *single-qubit* gate generators (one or more gates acting on individual wires)
+    describe a product state and are therefore supported; a multi-qubit gate would
+    entangle the qubits and cannot be represented as a :class:`ProductState`.
+
+    Because it is a genuine :class:`ProductState`, it works with every strategy that
+    accepts product-state inputs (e.g. the m-Pfaffian expectation-value strategy),
+    while still decomposing into its defining gates for the gate-based paths.
+    """
+
     @staticmethod
     def compute_decomposition(
         *params: TensorLike,
@@ -20,17 +35,51 @@ class StatePrepFromGates(StatePrepBase):
         gate_generator: Callable[[WiresLike], Iterator[Operation]] = hyperparameters["gate_generator"]
         return [op for op in gate_generator(wires)]
 
+    @staticmethod
+    def _product_amplitudes_from_gates(
+        gate_generator: Callable[[WiresLike], Iterator[Operation]],
+        wires: WiresLike,
+    ) -> np.ndarray:
+        """Compute the ``(n, 2)`` per-qubit amplitudes produced by the gate generator.
+
+        Each qubit starts in :math:`|0\\rangle` and the single-qubit gates yielded by
+        ``gate_generator`` are applied in order. A gate acting on more than one wire
+        entangles the qubits and is rejected with a :class:`ValueError`.
+        """
+        wires = Wires(wires)
+        n = len(wires)
+        wire_to_index = {w: i for i, w in enumerate(wires)}
+
+        # Each qubit starts in |0> = [1, 0].
+        amplitudes = np.zeros((n, 2), dtype=complex)
+        amplitudes[:, 0] = 1.0
+
+        # Stop recording so that materialising the gates here does not queue them onto
+        # the active tape (the StatePrepFromGates op itself is what gets queued).
+        with qml.QueuingManager.stop_recording():
+            for op in gate_generator(wires):
+                if isinstance(op, qml.Identity):
+                    continue
+                if len(op.wires) != 1:
+                    raise ValueError(
+                        f"StatePrepFromGates can only be represented as a ProductState when its "
+                        f"gate generator yields single-qubit gates, but got {op} acting on "
+                        f"{len(op.wires)} wires."
+                    )
+                idx = wire_to_index[op.wires[0]]
+                matrix = np.asarray(qml.math.toarray(op.matrix()), dtype=complex)
+                amplitudes[idx] = matrix @ amplitudes[idx]
+        return amplitudes
+
     def __init__(
         self,
         gate_generator: Callable[[WiresLike], Iterator[Operation]],
         wires: Optional[WiresLike] = None,
     ):
-        super().__init__(wires=wires)
         self.gate_generator = gate_generator
+        amplitudes = self._product_amplitudes_from_gates(gate_generator, wires)
+        super().__init__(amplitudes, wires=wires, validate_norm=False)
         self.hyperparameters["gate_generator"] = gate_generator
-
-    def state_vector(self, wire_order: Optional[WiresLike] = None) -> TensorLike:
-        raise NotImplementedError("State vector is not defined for StatePrepFromGates")
 
     def decomposition_generator(self) -> Iterator[Operation]:
         return self.gate_generator(self.wires)

--- a/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
+++ b/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
@@ -428,6 +428,240 @@ class TestMPfaffianExpvalStrategy:
         np.testing.assert_allclose(got, ref, atol=ATOL)
 
 
+class TestMPfaffianDecompositionCache:
+    """Correctness of the memoized Pauli->Majorana decomposition.
+
+    The cache must never change numerical output: it only avoids recomputing a
+    pure function of the observable + device wires. These tests exercise the two
+    cache tiers (weakref-validated identity, and structural) and the hazards the
+    optimization could introduce: shared Pauli structure with different
+    coefficients, object churn / id reuse, batched covariance, and autograd.
+    """
+
+    def setup_method(self):
+        # Start every test from a clean cache so hits/misses are deterministic.
+        from matchcake.devices.expval_strategies.m_pfaffian.m_pfaffian_expval_strategy import (
+            _DecompositionCache,
+        )
+
+        self.cache = _DecompositionCache
+        self.cache.clear()
+        self.strat = MPfaffianExpvalStrategy()
+
+    def _setup(self, n, seed):
+        psi = random_product_state(n, seed=seed)
+        wires = list(range(n))
+        prod_state = ProductState(psi, wires=wires)
+        psi_flat = np.array(prod_state.state_vector()).reshape(-1)
+        tilde_L = build_tilde_lambda(prod_state, wires)
+        return prod_state, psi_flat, tilde_L, wires
+
+    def test_repeated_calls_same_object_match(self):
+        """Calling twice with the same observable (a cache hit) matches brute force."""
+        prod, psi_flat, tilde_L, wires = self._setup(3, 1)
+        n = len(wires)
+        H = 0.5 * qml.X(0) + 0.3 * qml.Z(0) @ qml.Z(1) + 0.2 * qml.Y(0) @ qml.X(2)
+        ref = sum(float(c) * brute_force_expval(psi_flat, op, n) for c, op in zip(*H.terms()))
+        first = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+        # The identity cache should now hold this observable.
+        assert id(H) in self.cache._id_cache
+        second = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+        np.testing.assert_allclose(first, ref, atol=ATOL)
+        np.testing.assert_allclose(second, first, atol=0.0)  # bit-for-bit on a hit
+
+    def test_same_structure_different_coeffs(self):
+        """Two Hamiltonians sharing Pauli structure but different coeffs must not collide.
+
+        They share a structural-cache entry (coeff-independent) yet each must use
+        its own coefficients via the recomputed scalar_coeffs.
+        """
+        prod, psi_flat, tilde_L, wires = self._setup(3, 2)
+        n = len(wires)
+        ops = [qml.X(0) @ qml.X(1), qml.Z(0) @ qml.Z(2), qml.Y(1)]
+        H1 = qml.Hamiltonian([0.5, -0.3, 0.7], ops)
+        H2 = qml.Hamiltonian([1.1, 0.9, -0.2], ops)
+        for H in (H1, H2):
+            ref = sum(float(c) * brute_force_expval(psi_flat, op, n) for c, op in zip(*H.terms()))
+            got = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+            np.testing.assert_allclose(got, ref, atol=ATOL, err_msg=f"coeffs={H.terms()[0]}")
+        # Distinct objects -> two identity entries, but a single shared structure.
+        assert len(self.cache._struct_cache) == 1
+
+    def test_stale_id_entry_is_not_trusted(self):
+        """A poisoned identity entry whose object is gone must be ignored, not returned.
+
+        Simulates the id-reuse hazard: a dead weakref in the id cache must never
+        produce a false hit for a different observable that lands on the same id.
+        """
+        prod, psi_flat, tilde_L, wires = self._setup(2, 3)
+        n = len(wires)
+        H = qml.X(0) @ qml.X(1)
+        oid = id(H)
+        # Poison the cache: map this id to a WRONG payload behind a dead weakref.
+        import weakref
+        from collections import OrderedDict
+
+        dead = ProductState(np.array([[1.0, 0.0]], dtype=complex), wires=[0])
+        ref_dead = weakref.ref(dead)
+        del dead  # weakref now dead
+        bogus_payload = OrderedDict({2: (np.array([[0, 1]]), np.array([999.0]))})
+        self.cache._id_cache[oid] = (ref_dead, ((0, 1), 5), bogus_payload)
+
+        ref = brute_force_expval(psi_flat, H, n)
+        got = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+        np.testing.assert_allclose(got, ref, atol=ATOL)
+
+    def test_object_churn_no_false_hits(self):
+        """Many freshly created Hamiltonians (ids recycled by GC) all stay correct."""
+        prod, psi_flat, tilde_L, wires = self._setup(3, 4)
+        n = len(wires)
+        rng = np.random.RandomState(123)
+        for _ in range(50):
+            c = rng.uniform(-1, 1, 3)
+            H = qml.Hamiltonian(list(c), [qml.X(0) @ qml.X(1), qml.Y(0) @ qml.Z(2), qml.Z(1)])
+            ref = sum(float(cc) * brute_force_expval(psi_flat, op, n) for cc, op in zip(*H.terms()))
+            got = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+            np.testing.assert_allclose(got, ref, atol=ATOL)
+            del H  # free the id for potential reuse next iteration
+
+    def test_batched_covariance(self):
+        """A leading batch dimension on the covariance matrix is preserved."""
+        prod, psi_flat, tilde_L, wires = self._setup(3, 5)
+        H = 0.5 * qml.X(0) + 0.3 * qml.Z(0) @ qml.Z(1) + 0.4 * qml.X(0) @ qml.X(2)
+        scales = torch.tensor([1.0, 0.7, -0.5], dtype=tilde_L.dtype)
+        batched = torch.stack([s * tilde_L for s in scales])
+        got = self.strat(prod, H, extended_covariance_matrix=batched)
+        assert tuple(got.shape) == (3,)
+        for b in range(3):
+            single = float(self.strat(prod, H, extended_covariance_matrix=batched[b]))
+            np.testing.assert_allclose(float(got[b]), single, atol=ATOL)
+
+    def test_cache_hit_preserves_autograd(self):
+        """Gradients w.r.t. the covariance matrix flow on both miss and (cached) hit."""
+        prod, psi_flat, tilde_L, wires = self._setup(2, 6)
+        H = 0.5 * qml.X(0) + 0.3 * qml.Z(0) @ qml.Z(1) + 0.2 * qml.X(0) @ qml.Y(1)
+
+        def value_and_grad():
+            x = tilde_L.clone().to(torch.float64).requires_grad_(True)
+            out = self.strat(prod, H, extended_covariance_matrix=x)
+            out.backward()
+            return float(out.detach()), x.grad.clone()
+
+        v1, g1 = value_and_grad()  # cache miss populates
+        v2, g2 = value_and_grad()  # cache hit
+        np.testing.assert_allclose(v1, v2, atol=ATOL)
+        np.testing.assert_allclose(g1.numpy(), g2.numpy(), atol=ATOL)
+        # Finite-difference check along an antisymmetric direction (the covariance
+        # matrix lives on the skew-symmetric manifold, so a free per-entry FD would
+        # ignore the x_ij = -x_ji coupling that autograd correctly accounts for).
+        rng = np.random.RandomState(0)
+        base = tilde_L.clone().to(torch.float64)
+        M = rng.randn(*base.shape)
+        V = torch.tensor(M - M.T, dtype=torch.float64)  # antisymmetric direction
+        eps = 1e-6
+        plus = float(self.strat(prod, H, extended_covariance_matrix=base + eps * V))
+        minus = float(self.strat(prod, H, extended_covariance_matrix=base - eps * V))
+        fd_dir = (plus - minus) / (2 * eps)
+        analytic_dir = float((g1 * V).sum())
+        np.testing.assert_allclose(analytic_dir, fd_dir, atol=1e-4)
+
+    def test_inplace_coeff_change_same_object_not_stale(self):
+        """Mutating a reused observable's coefficients in place must not return a stale value.
+
+        The cache stores only the coefficient-independent structure; coefficients are
+        read live every call. A regression here would silently return the previous
+        coefficients for a reused Hamiltonian object.
+        """
+        prod, psi_flat, tilde_L, wires = self._setup(2, 7)
+        n = len(wires)
+        c = torch.tensor([0.5, 0.3])
+        H = qml.Hamiltonian(c, [qml.X(0) @ qml.X(1), qml.Z(0) @ qml.Z(1)])
+        self.strat(prod, H, extended_covariance_matrix=tilde_L)  # caches structure
+        with torch.no_grad():
+            c[0] = 5.0
+            c[1] = -1.7
+        got = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))  # same object
+        ref = 5.0 * brute_force_expval(psi_flat, qml.X(0) @ qml.X(1), n) - 1.7 * brute_force_expval(
+            psi_flat, qml.Z(0) @ qml.Z(1), n
+        )
+        np.testing.assert_allclose(got, ref, atol=ATOL)
+
+    def test_same_object_different_device_wires(self):
+        """Reusing one observable object across devices of different size stays correct.
+
+        The identity cache is keyed by (wires, matrix size); a context mismatch must
+        force recomputation rather than returning the wrong-sized decomposition.
+        """
+        H = qml.X(0) @ qml.X(1)  # single object reused below
+        for n, seed in [(2, 0), (4, 1), (2, 0)]:  # revisit n=2 last to test re-entry
+            wires = list(range(n))
+            prod = ProductState(random_product_state(n, seed), wires=wires)
+            psi_flat = np.array(prod.state_vector()).reshape(-1)
+            tilde_L = build_tilde_lambda(prod, wires)
+            ref = brute_force_expval(psi_flat, H, n)
+            got = float(self.strat(prod, H, extended_covariance_matrix=tilde_L))
+            np.testing.assert_allclose(got, ref, atol=ATOL, err_msg=f"n={n}")
+
+    def test_same_object_dtype_switch(self):
+        """A cache hit must honour the covariance matrix dtype of the current call."""
+        prod, psi_flat, tilde_L, wires = self._setup(3, 8)
+        n = len(wires)
+        H = 0.5 * qml.X(0) + 0.3 * qml.Z(0) @ qml.Z(1) + 0.2 * qml.X(0) @ qml.X(2)
+        ref = sum(float(c) * brute_force_expval(psi_flat, op, n) for c, op in zip(*H.terms()))
+        for dtype, r_dtype in [(torch.float64, torch.float64), (torch.float32, torch.float32)]:
+            ext = tilde_L.to(dtype)
+            out = self.strat(prod, H, extended_covariance_matrix=ext)  # 2nd dtype is a hit
+            assert out.dtype == r_dtype
+            np.testing.assert_allclose(float(out), ref, atol=1e-5, err_msg=f"dtype={dtype}")
+
+    def test_lru_eviction_bounds_and_correctness(self):
+        """Exceeding MAXSIZE evicts oldest entries but never corrupts results."""
+        prod, psi_flat, tilde_L, wires = self._setup(3, 4)
+        n = len(wires)
+        # Many structurally distinct observables (different Pauli patterns).
+        pauli = {0: qml.X, 1: qml.Y, 2: qml.Z}
+        observables = []
+        for a in range(3):
+            for b in range(3):
+                for w0 in range(n):
+                    observables.append(pauli[a](w0) @ pauli[b]((w0 + 1) % n))
+        original_maxsize = self.cache.MAXSIZE
+        try:
+            self.cache.MAXSIZE = 5
+            for obs in observables:
+                ref = brute_force_expval(psi_flat, obs, n)
+                got = float(self.strat(prod, obs, extended_covariance_matrix=tilde_L))
+                np.testing.assert_allclose(got, ref, atol=ATOL, err_msg=str(obs))
+                assert len(self.cache._struct_cache) <= self.cache.MAXSIZE
+                assert len(self.cache._id_cache) <= self.cache.MAXSIZE
+        finally:
+            self.cache.MAXSIZE = original_maxsize
+
+    def test_thread_safety_concurrent_observables(self):
+        """Concurrent calls from many threads return correct, uncorrupted results."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        prod, psi_flat, tilde_L, wires = self._setup(3, 11)
+        n = len(wires)
+        rng = np.random.RandomState(7)
+        pauli = {0: qml.X, 1: qml.Y, 2: qml.Z}
+        jobs = []
+        for _ in range(240):
+            a, b = rng.randint(0, 3), rng.randint(0, 3)
+            w0 = rng.randint(0, n)
+            obs = pauli[a](w0) @ pauli[b]((w0 + 1) % n)
+            jobs.append((obs, brute_force_expval(psi_flat, obs, n)))
+
+        def work(job):
+            obs, ref = job
+            got = float(self.strat(prod, obs, extended_covariance_matrix=tilde_L))
+            return abs(got - ref)
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            errs = list(ex.map(work, jobs))
+        assert max(errs) < ATOL, f"max error {max(errs)}"
+
+
 class TestMPfaffianEndToEnd:
     """End-to-end test of MPfaffianExpvalStrategy through the full NIF device QNode.
 

--- a/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
@@ -275,7 +275,7 @@ class TestNIFDeviceMethodsAndProperties:
         dev = _make_zero_state_device(n_wires=2)
         state_prep = StatePrepFromGates(lambda wires: [qml.Hadamard(wires=wires[0])], wires=[0, 1])
         dev._state_prep_op = state_prep
-        observable = qml.X(0) @ qml.Z(1)
+        observable = qml.Projector(np.array([1, 0, 0, 1]) / np.sqrt(2), wires=[0, 1])
         with pytest.raises(DeviceError):
             dev.exact_expval(observable)
 


### PR DESCRIPTION
# Description

This pull request introduces significant performance and maintainability improvements for the m-Pfaffian expectation value strategy and enhances the `StatePrepFromGates` state preparation operation. The most impactful change is the addition of a two-tiered, thread-safe memoization cache for the Pauli-to-Majorana decomposition, which greatly reduces redundant computation during repeated expectation value evaluations. Additionally, the state preparation logic is refactored to ensure compatibility with product-state-based strategies and to more robustly handle gate application.

**Majorana Decomposition Caching and Expectation Value Evaluation:**

* Added a thread-safe, two-level LRU cache (`_DecompositionCache`) to memoize the Pauli-to-Majorana decomposition, keyed both by observable object identity (with weakref validation) and by observable structure, to avoid redundant recomputation and improve performance for repeated evaluations. The cache is shared across all strategy instances within a process and is robust to in-place coefficient changes.
* Refactored the main expectation value computation in `MPfaffianExpvalStrategy` to use the cached decomposition and vectorized operations, replacing the previous per-term loop and manual decomposition with a payload fetched from the cache. This change results in cleaner, faster, and more maintainable code.
* Updated the class documentation and logic to clarify that the decomposition is now memoized and only the coefficients and covariance matrix are processed per call.

**Observable Terms Handling:**

* Replaced the `_to_hamiltonian` method with `_terms_of`, which directly extracts coefficients and operators from the observable using `terms()`, falling back to a trivial single-term if necessary. This ensures correct cache operation and improves efficiency.
* Improved the `can_execute` method to use the cache for fast-path checks and to directly verify Pauli decomposability, reducing unnecessary work.

**State Preparation via Gates:**

* Refactored `StatePrepFromGates` to inherit from `ProductState` instead of `StatePrepBase`, ensuring compatibility with all strategies that support product-state inputs.
* Added a private method `_product_amplitudes_from_gates` that computes per-qubit amplitudes by applying only single-qubit gates, raising an error if entangling gates are encountered. This ensures the operation truly represents a product state.

These changes collectively improve the efficiency, correctness, and extensibility of expectation value computations and state preparation in the codebase.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
