### PR TITLE
Add chunking support for Pfaffian computations

### DIFF
--- a/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
+++ b/src/matchcake/devices/expval_strategies/m_pfaffian/m_pfaffian_expval_strategy.py
@@ -285,6 +285,7 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
 
         payload = _DecompositionCache.get_payload(observable, self._terms_of, device_wires_tuple, n_total)
 
+        chunk_size = kwargs.get("pfaffian_chunk_size", None)
         r_dtype = infer_real_dtype(ext_cov_matrix)
         ext_cov_matrix_t: Optional[TensorLike] = None  # lazily built for the sector-2 read
         total_re: Any = np.float64(0.0)
@@ -298,7 +299,9 @@ class MPfaffianExpvalStrategy(ExpvalStrategy):
                 j_idx = index_sets[:, 1]
                 pf_values = ext_cov_matrix_t[..., i_idx, j_idx]  # (..., n_terms)
             else:
-                pf_values = sector_pfaffian_features(ext_cov_matrix, index_sets, dtype=r_dtype)  # (..., n_terms)
+                pf_values = sector_pfaffian_features(
+                    ext_cov_matrix, index_sets, dtype=r_dtype, chunk_size=chunk_size
+                )  # (..., n_terms)
 
             scalar_coeffs_t = torch.as_tensor(scalar_coeffs, dtype=pf_values.dtype, device=pf_values.device)
             total_re = total_re + pf_values @ scalar_coeffs_t  # (...)

--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -109,6 +109,9 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         transition matrices, lookup table, observables). Defaults to ``torch.complex128`` to preserve maximum
         precision. Set to e.g. ``torch.complex64`` to reduce memory usage and computation cost.
     :type c_dtype: torch.dtype
+    :keyword pfaffian_chunk_size: Max number of matrices reduced per batched Pfaffian call, forwarded to
+        :func:`matchcake.utils.pfaffian` to bound memory. Defaults to ``None`` (no chunking).
+    :type pfaffian_chunk_size: Optional[int]
 
     :Note: This device is a simulator for non-interacting fermions. It is based on the ``default.qubit`` device.
     :Note: This device supports batch execution.
@@ -244,6 +247,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
                 self.DEFAULT_STAR_STATE_FINDING_STRATEGY,
             )
         )
+        self.pfaffian_chunk_size: Optional[int] = kwargs.get("pfaffian_chunk_size", None)
         self.p_bar: Optional[tqdm.tqdm] = kwargs.get("p_bar", None)
         self.show_progress = kwargs.get("show_progress", self.p_bar is not None)
         self.apply_metadata: defaultdict = defaultdict()
@@ -533,6 +537,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
                 self.state_prep_op,
                 observable,
                 extended_covariance_matrix=self.extended_covariance_matrix,
+                pfaffian_chunk_size=self.pfaffian_chunk_size,
             )
         if self.clifford_expval_strategy.can_execute(self.state_prep_op, observable):  # pragma: no cover
             return self.clifford_expval_strategy(
@@ -550,6 +555,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
                 extended_covariance_matrix=self.extended_covariance_matrix,
                 global_sptm=self.global_sptm.matrix(),
                 prob_func=self.probability,
+                pfaffian_chunk_size=self.pfaffian_chunk_size,
             )
 
         raise DeviceError(
@@ -797,6 +803,7 @@ class NonInteractingFermionicDevice(qml.devices.Device):
             global_sptm=self.global_sptm.matrix(),
             majorana_getter=self.majorana_getter,
             show_progress=kwargs.pop("show_progress", self.show_progress),
+            pfaffian_chunk_size=kwargs.pop("pfaffian_chunk_size", self.pfaffian_chunk_size),
         )
         if isinstance(self.state_prep_op, ProductState):
             strategy_kwargs["covariance_matrix"] = self.covariance_matrix

--- a/src/matchcake/devices/probability_strategies/lookup_table_strategy.py
+++ b/src/matchcake/devices/probability_strategies/lookup_table_strategy.py
@@ -68,7 +68,8 @@ class LookupTableStrategy(ProbabilityStrategy):
                 wire_indices = np.array([all_wires.indices(Wires(w)) for w in batch_wires])  # (B, k)
 
         obs = lookup_table(system_state, target_arr, wire_indices, show_progress=show_progress)
-        return qml.math.real(utils.pfaffian(obs, sign=False))
+        chunk_size = kwargs.get("pfaffian_chunk_size", None)
+        return qml.math.real(utils.pfaffian(obs, sign=False, chunk_size=chunk_size))
 
     def can_execute(self, state_prep_op: StatePrepBase) -> bool:
         """Return True for basis-state inputs.

--- a/src/matchcake/devices/probability_strategies/product_state_strategy.py
+++ b/src/matchcake/devices/probability_strategies/product_state_strategy.py
@@ -149,6 +149,11 @@ class ProductStateProbabilityStrategy(ProbabilityStrategy):
         and returns ``(B,)``. When all outcomes share the same wires (the device default),
         the batch is handled in one vectorized determinant call over a ``(B, 2k, 2k)`` stack.
 
+        Pass ``pfaffian_chunk_size`` to bound peak memory: the Pfaffian over the
+        ``(..., 2k, 2k)`` stack is then reduced in slices of at most that many matrices along the
+        flattened batch axis instead of all at once, which caps the determinant/backward
+        workspace. Defaults to ``None`` (no chunking).
+
         :param state_prep_op: State preparation operation (not used directly; the evolved
             covariance matrix is passed via ``covariance_matrix``).
         :type state_prep_op: StatePrepBase
@@ -209,7 +214,8 @@ class ProductStateProbabilityStrategy(ProbabilityStrategy):
                 )
 
         combined = lambda_t_w + lambda_y
-        prob = (1.0 / 2**k) * qml.math.real(utils.pfaffian(combined, sign=False))
+        chunk_size = kwargs.get("pfaffian_chunk_size", None)
+        prob = (1.0 / 2**k) * qml.math.real(utils.pfaffian(combined, sign=False, chunk_size=chunk_size))
         return convert_and_cast_like(prob, covariance_matrix)
 
     def can_execute(self, state_prep_op: StatePrepBase) -> bool:

--- a/src/matchcake/utils/_pfaffian.py
+++ b/src/matchcake/utils/_pfaffian.py
@@ -14,7 +14,7 @@ from .torch_utils import infer_real_dtype
 _pfaffian_epsilon_lock = threading.Lock()
 
 
-def signed_pfaffian(matrix: TensorLike, dtype: Optional[torch.dtype] = None) -> TensorLike:
+def signed_pfaffian(matrix: TensorLike, dtype: Optional[torch.dtype] = None, **kwargs) -> TensorLike:
     """
     Compute the signed Pfaffian of a real antisymmetric matrix (or batch).
 
@@ -33,13 +33,11 @@ def signed_pfaffian(matrix: TensorLike, dtype: Optional[torch.dtype] = None) -> 
     """
     if dtype is None:
         dtype = infer_real_dtype(matrix)
-    return pfaffian(matrix, sign=True, dtype=dtype)
+    return pfaffian(matrix, sign=True, dtype=dtype, **kwargs)
 
 
 def sector_pfaffian_features(
-    cov_matrix: TensorLike,
-    index_sets: np.ndarray,
-    dtype: Optional[torch.dtype] = None,
+    cov_matrix: TensorLike, index_sets: np.ndarray, dtype: Optional[torch.dtype] = None, **kwargs
 ) -> TensorLike:
     """
     Return a ``(..., n_terms)`` tensor of signed Pfaffians of principal submatrices.
@@ -71,8 +69,27 @@ def sector_pfaffian_features(
         # Fast path: Pf of 2x2 [[0, a], [-a, 0]] = a.
         result = submatrices[..., 0, 1]  # (..., n_terms)
     else:
-        result = pfaffian(submatrices, sign=True)  # (..., n_terms)
+        result = pfaffian(submatrices, sign=True, **kwargs)  # (..., n_terms)
     return convert_and_cast_like(result, cov_matrix)
+
+
+def _pfaffian_kernel(matrix_t: torch.Tensor, sign: bool, epsilon: float) -> torch.Tensor:
+    """Compute the Pfaffian of a batch of matrices already cast to a torch tensor.
+
+    :param matrix_t: Skew-symmetric matrix (or batch) of shape ``(..., 2n, 2n)``.
+    :type matrix_t: torch.Tensor
+    :param sign: When ``True`` return the signed Pfaffian, otherwise its magnitude.
+    :type sign: bool
+    :param epsilon: Floor applied to the determinant magnitude in the ``sign=False`` path.
+    :type epsilon: float
+    :return: Pfaffian of shape ``(...,)``.
+    :rtype: torch.Tensor
+    """
+    if sign:
+        return torch_pfaffian.pfaffian(matrix_t, sign=True)
+    with _pfaffian_epsilon_lock:
+        torch_pfaffian.PfaffianStrategy.EPSILON = epsilon
+        return torch_pfaffian.PfaffianDet.apply(matrix_t)
 
 
 def pfaffian(
@@ -80,6 +97,7 @@ def pfaffian(
     sign: bool = False,
     epsilon: float = 1e-32,
     dtype: Optional[torch.dtype] = None,
+    chunk_size: Optional[int] = None,
 ) -> TensorLike:
     """
     Compute the Pfaffian of a real or complex skew-symmetric matrix ``A`` (``A = -A^T``).
@@ -87,6 +105,11 @@ def pfaffian(
     Delegates to TorchPfaffian. When ``sign`` is ``False`` (default) the magnitude
     ``sqrt(|det(A)|)`` is returned, which is the quantity needed for probability computations
     where the sign is irrelevant. When ``sign`` is ``True`` the signed Pfaffian is returned.
+
+    For a large batch the pfaffian workspace and its backward graph dominate
+    memory and can exceed device memory. Pass ``chunk_size`` to bound that footprint: the
+    leading batch axis is then processed in slices of at most ``chunk_size`` matrices, each
+    reduced independently and concatenated, instead of all at once.
 
     Note: with a complex ``matrix`` this function may not behave as expected. The signed path
     (``sign=True``) relies on a kernel that discards the imaginary part without warning, so it
@@ -101,19 +124,21 @@ def pfaffian(
         avoid numerical instabilities. Defaults to ``1e-32``.
     :param dtype: Optional working dtype to cast ``matrix`` to before the computation.
         Defaults to ``None`` (the input dtype is preserved).
+    :param chunk_size: Maximum number of matrices to reduce at once along the flattened leading
+        batch axis. Defaults to ``None`` (the whole batch is reduced in one shot).
     :return: Pfaffian of the matrix, of shape ``(...,)``.
     :rtype: TensorLike
     """
     matrix_t = torch_utils.to_tensor(matrix, dtype=dtype)
-    if sign:
-        result = torch_pfaffian.pfaffian(matrix_t, sign=True)
+    batch_shape = matrix_t.shape[:-2]
+
+    if chunk_size is not None and len(batch_shape) > 0 and batch_shape.numel() > chunk_size:
+        flat = matrix_t.reshape(-1, matrix_t.shape[-2], matrix_t.shape[-1])  # (B, 2n, 2n)
+        pieces = [
+            _pfaffian_kernel(flat[start : start + chunk_size], sign, epsilon)
+            for start in range(0, flat.shape[0], chunk_size)
+        ]
+        result = torch.cat(pieces, dim=0).reshape(batch_shape)
     else:
-        # ``PfaffianDet`` differentiates straight through ``det`` and ``sqrt``; its gradient
-        # stays consistent with finite differences for complex matrices, whereas the analytic
-        # backward of the gradient-enabled magnitude strategy does not. The global ``EPSILON``
-        # it reads is mutated under a lock for thread safety.
-        # ``PfaffianDet`` is also faster in general in CPU and can be used with CUDA.
-        with _pfaffian_epsilon_lock:
-            torch_pfaffian.PfaffianStrategy.EPSILON = epsilon
-            result = torch_pfaffian.PfaffianDet.apply(matrix_t)
+        result = _pfaffian_kernel(matrix_t, sign, epsilon)
     return convert_and_cast_like(result, matrix)

--- a/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
+++ b/tests/test_devices/test_expval_strategies/test_m_pfaffian/test_m_pfaffian_expval_strategy.py
@@ -353,6 +353,23 @@ class TestMPfaffianExpvalStrategy:
         got = float(self.strat(prod_state, H, extended_covariance_matrix=tilde_L))
         np.testing.assert_allclose(got, ref, atol=ATOL)
 
+    @pytest.mark.parametrize("chunk_size", [1, 2, 100])
+    def test_chunk_size_matches_unchunked(self, chunk_size):
+        n = 3
+        psi = random_product_state(n, seed=7)
+        wires = list(range(n))
+        prod_state = ProductState(psi, wires=wires)
+        tilde_L = build_tilde_lambda(prod_state, wires)
+        # Several terms whose Majorana ranks land in the sector_pfaffian_features (sector >= 4)
+        # path, with more than one term per sector so the chunking actually engages.
+        H = qml.Hamiltonian(
+            [0.5, 1.3, -0.7, 0.9],
+            [qml.X(0) @ qml.Y(1), qml.Y(0) @ qml.X(2), qml.Z(0) @ qml.X(1) @ qml.Y(2), qml.X(1) @ qml.X(2)],
+        )
+        unchunked = float(self.strat(prod_state, H, extended_covariance_matrix=tilde_L))
+        chunked = float(self.strat(prod_state, H, extended_covariance_matrix=tilde_L, pfaffian_chunk_size=chunk_size))
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL)
+
     @pytest.mark.parametrize("n,seed", [(1, 0), (2, 1), (3, 2), (2, 3)])
     def test_single_qubit_xyz(self, n, seed):
         """X, Y, Z expectations match brute-force for all qubits."""

--- a/tests/test_devices/test_probability_strategies/test_lookup_table_strategy.py
+++ b/tests/test_devices/test_probability_strategies/test_lookup_table_strategy.py
@@ -1,16 +1,41 @@
+import itertools
 from unittest.mock import Mock
 
 import numpy as np
 import pennylane as qml
 import pytest
 
+from matchcake import NonInteractingFermionicDevice
 from matchcake.devices.probability_strategies import LookupTableStrategy
+from matchcake.operations import MatchgateOperation
+
+from ...configs import ATOL_SCALAR_COMPARISON, set_seed
 
 
 class TestLookupTableStrategy:
     @pytest.fixture
     def strategy(self):
         return LookupTableStrategy()
+
+    @pytest.mark.parametrize("chunk_size", [1, 2, 100])
+    def test_chunked_matches_unchunked(self, strategy, chunk_size):
+        set_seed()
+        n_wires = 3
+        gate_seeds = [40 + idx for idx in range(n_wires - 1)]
+        nif_dev = NonInteractingFermionicDevice(wires=range(n_wires))
+
+        def circuit():
+            qml.BasisState(np.zeros(n_wires, dtype=int), wires=range(n_wires))
+            for idx, seed in enumerate(gate_seeds):
+                MatchgateOperation.random(wires=[idx, idx + 1], seed=seed)
+            return qml.probs(wires=range(n_wires))
+
+        qml.QNode(circuit, nif_dev)()
+        outcomes = np.array(list(itertools.product([0, 1], repeat=n_wires)))  # (8, 3)
+
+        unchunked = np.asarray(nif_dev.get_states_probability(outcomes, nif_dev.wires))
+        chunked = np.asarray(nif_dev.get_states_probability(outcomes, nif_dev.wires, pfaffian_chunk_size=chunk_size))
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_SCALAR_COMPARISON)
 
     def test_wires_as_int(self, strategy):
         lookup_table_mock = Mock()

--- a/tests/test_devices/test_probability_strategies/test_product_state_strategy.py
+++ b/tests/test_devices/test_probability_strategies/test_product_state_strategy.py
@@ -395,6 +395,127 @@ class TestProductStateProbabilityStrategy:
         assert grid_probs.shape == (3, 2)
         np.testing.assert_allclose(grid_probs, ref_probs, atol=ATOL_SCALAR_COMPARISON)
 
+    @pytest.mark.parametrize("chunk_size", [1, 2, 3, 5, 8, 100])
+    def test_chunked_grid_matches_unchunked(self, strategy: ProductStateProbabilityStrategy, chunk_size: int) -> None:
+        set_seed()
+        n_wires = 3
+        per_qubit = _random_qubit_amplitudes(n_wires, seed=82)
+        all_wires = Wires(range(n_wires))
+
+        def covariance_for(seed: int):
+            nif_dev = NonInteractingFermionicDevice(wires=range(n_wires))
+
+            def circuit():
+                ProductState(per_qubit, wires=range(n_wires))
+                MatchgateOperation.random(wires=[0, 1], seed=seed)
+                MatchgateOperation.random(wires=[1, 2], seed=seed + 1)
+                return qml.probs(wires=range(n_wires))
+
+            qml.QNode(circuit, nif_dev)()
+            return np.asarray(nif_dev.covariance_matrix), nif_dev.state_prep_op
+
+        cov_a, state_prep_op = covariance_for(31)
+        cov_b, _ = covariance_for(33)
+        cov_c, _ = covariance_for(35)
+        cov_batched = np.stack([cov_a, cov_b, cov_c])  # (B_in=3, 2n, 2n)
+        outcomes = np.array(list(itertools.product([0, 1], repeat=n_wires)))  # (B_out=8, n=3)
+
+        unchunked = np.asarray(
+            strategy(
+                state_prep_op=state_prep_op,
+                target_binary_states=outcomes,
+                wires=all_wires,
+                all_wires=all_wires,
+                covariance_matrix=cov_batched,
+            )
+        )
+        chunked = np.asarray(
+            strategy(
+                state_prep_op=state_prep_op,
+                target_binary_states=outcomes,
+                wires=all_wires,
+                all_wires=all_wires,
+                covariance_matrix=cov_batched,
+                pfaffian_chunk_size=chunk_size,
+            )
+        )
+        assert chunked.shape == unchunked.shape == (8, 3)
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_SCALAR_COMPARISON)
+
+    def test_chunked_single_outcome_matches_unchunked(self, strategy: ProductStateProbabilityStrategy) -> None:
+        set_seed()
+        n_wires = 2
+        per_qubit = _random_qubit_amplitudes(n_wires, seed=84)
+
+        nif_dev = NonInteractingFermionicDevice(wires=range(n_wires))
+
+        def circuit():
+            ProductState(per_qubit, wires=range(n_wires))
+            MatchgateOperation.random(wires=[0, 1], seed=25)
+            return qml.probs(wires=range(n_wires))
+
+        qml.QNode(circuit, nif_dev)()
+        lambda_t = nif_dev.covariance_matrix
+        all_wires = nif_dev.wires
+        outcome = np.array([1, 0])
+
+        unchunked = float(
+            strategy(
+                state_prep_op=nif_dev.state_prep_op,
+                target_binary_states=outcome,
+                wires=all_wires,
+                all_wires=all_wires,
+                covariance_matrix=lambda_t,
+            )
+        )
+        chunked = float(
+            strategy(
+                state_prep_op=nif_dev.state_prep_op,
+                target_binary_states=outcome,
+                wires=all_wires,
+                all_wires=all_wires,
+                covariance_matrix=lambda_t,
+                pfaffian_chunk_size=1,
+            )
+        )
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_SCALAR_COMPARISON)
+
+    def test_chunked_device_matches_unchunked_device(self) -> None:
+        set_seed()
+        n_wires = 3
+        per_qubit = _random_qubit_amplitudes(n_wires, seed=86)
+        gate_seeds = [40 + idx for idx in range(n_wires - 1)]
+
+        chunked_dev = NonInteractingFermionicDevice(wires=range(n_wires), pfaffian_chunk_size=2)
+        plain_dev = NonInteractingFermionicDevice(wires=range(n_wires))
+
+        chunked_probs = _run_product_state_circuit(per_qubit, n_wires, gate_seeds, chunked_dev, list(range(n_wires)))
+        plain_probs = _run_product_state_circuit(per_qubit, n_wires, gate_seeds, plain_dev, list(range(n_wires)))
+
+        np.testing.assert_allclose(chunked_probs, plain_probs, atol=ATOL_SCALAR_COMPARISON)
+        np.testing.assert_allclose(chunked_probs.sum(), 1.0, atol=ATOL_SCALAR_COMPARISON)
+
+    def test_chunked_gradient_flow_gradcheck(self, strategy: ProductStateProbabilityStrategy) -> None:
+        set_seed()
+        n_wires = 2
+        sp = ProductState(np.array([0.6, 0.8, 0.6, 0.8], dtype=complex), wires=[0, 1])
+        all_outcomes = np.array(list(itertools.product([0, 1], repeat=n_wires)))  # (4, 2)
+        all_wires = Wires(range(n_wires))
+
+        def batch_probs(p):
+            cov = p - p.t()
+            return strategy(
+                state_prep_op=sp,
+                target_binary_states=all_outcomes,
+                wires=all_wires,
+                all_wires=all_wires,
+                covariance_matrix=cov,
+                pfaffian_chunk_size=2,
+            )
+
+        p = torch.randn(2 * n_wires, 2 * n_wires, dtype=torch.double, requires_grad=True)
+        assert torch.autograd.gradcheck(batch_probs, (p,), atol=1e-5, rtol=1e-4)
+
     def test_build_lambda_y_single(self, strategy: ProductStateProbabilityStrategy) -> None:
         y = np.array([0, 1, 0])
         lam = strategy.build_lambda_y(y, 3)

--- a/tests/test_utils/test_pfaffian.py
+++ b/tests/test_utils/test_pfaffian.py
@@ -63,6 +63,58 @@ class TestPfaffian:
         )
 
     @pytest.mark.parametrize("sign", [True, False])
+    @pytest.mark.parametrize("batch_shape", [(7,), (3, 5), (2, 3, 4)])
+    # chunk sizes 2, 3 and 4 leave a non-empty remainder chunk for the (7,) and (3, 5) batches
+    # (numel 7 and 15), exercising the case where the batch is not divisible by chunk_size.
+    @pytest.mark.parametrize("chunk_size", [1, 2, 3, 4, 100])
+    def test_pfaffian_chunked_matches_unchunked(self, sign, batch_shape, chunk_size):
+        matrix = self.skew_symmetric(6, batch_size=None)
+        matrix = np.broadcast_to(matrix, batch_shape + matrix.shape).copy()
+        for index in np.ndindex(*batch_shape):
+            matrix[index] = self.skew_symmetric(6, batch_size=None)
+        unchunked = np.asarray(pfaffian(matrix, sign=sign))
+        chunked = np.asarray(pfaffian(matrix, sign=sign, chunk_size=chunk_size))
+        assert chunked.shape == unchunked.shape == batch_shape
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_MATRIX_COMPARISON, rtol=RTOL_MATRIX_COMPARISON)
+
+    @pytest.mark.parametrize("sign", [True, False])
+    def test_pfaffian_chunk_size_single_matrix_is_noop(self, sign):
+        matrix = self.skew_symmetric(4)
+        chunked = pfaffian(matrix, sign=sign, chunk_size=1)
+        unchunked = pfaffian(matrix, sign=sign)
+        np.testing.assert_allclose(float(chunked), float(unchunked), atol=ATOL_SCALAR_COMPARISON)
+
+    @pytest.mark.parametrize("chunk_size", [1, 3, 100])
+    def test_signed_pfaffian_chunk_size_passthrough(self, chunk_size):
+        matrix = self.skew_symmetric(6, batch_size=7)
+        unchunked = np.asarray(signed_pfaffian(matrix))
+        chunked = np.asarray(signed_pfaffian(matrix, chunk_size=chunk_size))
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_MATRIX_COMPARISON, rtol=RTOL_MATRIX_COMPARISON)
+
+    @pytest.mark.parametrize("chunk_size", [1, 3, 100])
+    def test_sector_pfaffian_chunk_size_passthrough(self, chunk_size):
+        cov_matrix = self.skew_symmetric(8, batch_size=7)
+        index_sets = np.array([[0, 1, 2, 3], [2, 3, 4, 5], [4, 5, 6, 7]])
+        unchunked = np.asarray(sector_pfaffian_features(cov_matrix, index_sets))
+        chunked = np.asarray(sector_pfaffian_features(cov_matrix, index_sets, chunk_size=chunk_size))
+        np.testing.assert_allclose(chunked, unchunked, atol=ATOL_MATRIX_COMPARISON, rtol=RTOL_MATRIX_COMPARISON)
+
+    def test_pfaffian_chunked_grads_on_skew_manifold(self):
+        n = 6
+        n_upper = n * (n - 1) // 2
+        theta = torch.randn(5, n_upper, dtype=torch.float64).requires_grad_()
+
+        def chunked_signed(flat_upper):
+            upper = torch.zeros(flat_upper.shape[0], n, n, dtype=flat_upper.dtype)
+            idx = torch.triu_indices(n, n, offset=1)
+            upper = upper.clone()
+            upper[:, idx[0], idx[1]] = flat_upper
+            matrix = upper - upper.transpose(-1, -2)
+            return pfaffian(matrix, sign=True, chunk_size=2)
+
+        assert gradcheck(chunked_signed, (theta,), atol=ATOL_APPROX_COMPARISON, rtol=10 * RTOL_APPROX_COMPARISON)
+
+    @pytest.mark.parametrize("sign", [True, False])
     def test_pfaffian_odd_size_is_zero(self, sign):
         matrix = self.skew_symmetric(3)
         pf = pfaffian(matrix, sign=sign)


### PR DESCRIPTION
# Description

This pull request adds support for chunked Pfaffian computation across the codebase, which helps control memory usage for large batch sizes when evaluating expectation values and probabilities in non-interacting fermionic devices. The chunking feature is made configurable via a new `pfaffian_chunk_size` parameter, which is threaded through all relevant strategies and device methods. Extensive tests are added to ensure that chunked and unchunked computations produce consistent results and that gradients flow correctly.

**Chunked Pfaffian computation support:**

* Added a `chunk_size` (exposed as `pfaffian_chunk_size`) argument to the core `pfaffian` function in `src/matchcake/utils/_pfaffian.py`, which processes large batches in slices to bound memory usage. The function and its callers have been refactored to support this. (Fc8164a3L69R106, Fc8164a3L124R124, [[1]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899L17-R17) [[2]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899L36-R40) [[3]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899L74-R100)
* All strategies and device methods that compute probabilities or expectation values using Pfaffians now accept and propagate `pfaffian_chunk_size`, including `m_pfaffian_expval_strategy.py`, `lookup_table_strategy.py`, and `product_state_strategy.py`. [[1]](diffhunk://#diff-80a8b5073db17e428fc0c8ea2044aec9a32055397822f57f36ffc7ec54d34770R288) [[2]](diffhunk://#diff-80a8b5073db17e428fc0c8ea2044aec9a32055397822f57f36ffc7ec54d34770L301-R304) [[3]](diffhunk://#diff-468caba29ab8633456e0e36129838e4ee00441aedcdb62043ccb86f26163fc1eL71-R72) [[4]](diffhunk://#diff-9f6b85f48469eebc73f20c01e28e6cf5ca85d69669b3af23821ae6381139dc6eR152-R156) [[5]](diffhunk://#diff-9f6b85f48469eebc73f20c01e28e6cf5ca85d69669b3af23821ae6381139dc6eL212-R218) [[6]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R540) [[7]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R558) [[8]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R806) [[9]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R250)
* The `NonInteractingFermionicDevice` class now accepts a `pfaffian_chunk_size` keyword argument at construction and threads it to all relevant computations. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R112-R114) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R250)

**Documentation and API improvements:**

* Docstrings for all affected methods and strategies have been updated to document the new `pfaffian_chunk_size` parameter and its effect on memory usage. [[1]](diffhunk://#diff-9f6b85f48469eebc73f20c01e28e6cf5ca85d69669b3af23821ae6381139dc6eR152-R156) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R112-R114) [[3]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R109-R113) [[4]](diffhunk://#diff-a35727cb8592a9a8f9010ce4ef41daae713b016f05023fe86cec2ea6e71f3899R127-R143)

**Testing and validation:**

* Added comprehensive tests to verify that chunked and unchunked Pfaffian computations produce identical results and that chunking does not affect gradients. These include parametric tests for different chunk sizes in expectation value and probability strategies, as well as device-level tests. [[1]](diffhunk://#diff-6f39734b19b474fdd0083d57d034bd12d07889b4af94d6999cb81fd323b985f5R356-R372) [[2]](diffhunk://#diff-0380b8b5e86b1be1d6aee8b0873991c9c1873949150f6a6b33ed21e75fc55b7cR1-R39) [[3]](diffhunk://#diff-6d15edef2db5d379b45b791e8c0e455628762c392aa792917c448fda7e0629e3R398-R518)

These changes make the codebase more robust and scalable for large-batch computations on limited-memory hardware.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
