### PR TITLE
Polish the utilization of the probability strategy dispatcher

### DIFF
--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -53,9 +53,11 @@ from .expval_strategies.m_pfaffian._extended_covariance import (
 )
 from .expval_strategies.terms_splitter import TermsSplitter
 from .probability_strategies import (
+    CliffordSumStrategy,
+    ExplicitSumStrategy,
+    LookupTableStrategy,
     ProbabilityFuncDispatcher,
     ProductStateProbabilityStrategy,
-    get_probability_strategy,
 )
 from .sampling_strategies import SamplingStrategy, get_sampling_strategy
 from .star_state_finding_strategies import (
@@ -91,9 +93,6 @@ class NonInteractingFermionicDevice(qml.devices.Device):
 
     :kwargs: Additional keyword arguments
 
-    :keyword prob_strategy: The strategy to compute the probabilities. Can be either "lookup_table" or "explicit_sum".
-        Defaults to "lookup_table".
-    :type prob_strategy: str
     :keyword majorana_getter: The Majorana getter to use. Defaults to a new instance of MajoranaGetter.
     :type majorana_getter: MajoranaGetter
     :keyword contraction_method: The contraction method to use. Can be either None or "neighbours".
@@ -115,6 +114,9 @@ class NonInteractingFermionicDevice(qml.devices.Device):
 
     :Note: This device is a simulator for non-interacting fermions. It is based on the ``default.qubit`` device.
     :Note: This device supports batch execution.
+    :Note: Probabilities are routed by :attr:`prob_dispatcher`, a fixed ordered chain of strategies resolved by
+        each strategy's ``can_execute``. There is no keyword to select a strategy; to pin one, replace
+        :attr:`prob_dispatcher` on the constructed device.
     :Note: This device is in development, and its API is subject to change.
     """
 
@@ -137,7 +139,6 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         ProductState.__name__,
     }
 
-    DEFAULT_PROB_STRATEGY = "LookupTable"
     DEFAULT_CONTRACTION_METHOD = "neighbours"
     DEFAULT_SAMPLING_STRATEGY = "2QubitBy2QubitSampling"
     DEFAULT_STAR_STATE_FINDING_STRATEGY = "FromSampling"
@@ -234,8 +235,10 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         )
         self.prob_dispatcher: ProbabilityFuncDispatcher = ProbabilityFuncDispatcher(
             [
-                get_probability_strategy(kwargs.get("prob_strategy", self.DEFAULT_PROB_STRATEGY)),
+                LookupTableStrategy(),
                 ProductStateProbabilityStrategy(),
+                CliffordSumStrategy(),
+                ExplicitSumStrategy(),
             ]
         )
         self.contraction_strategy: ContractionStrategy = get_contraction_strategy(

--- a/src/matchcake/devices/probability_strategies/explicit_sum_strategy.py
+++ b/src/matchcake/devices/probability_strategies/explicit_sum_strategy.py
@@ -36,23 +36,37 @@ class ExplicitSumStrategy(ProbabilityStrategy):
         return np.reshape(state, [2] * num_wires)
 
     def can_execute(self, state_prep_op: StatePrepBase) -> bool:
-        """Return True for basis-state inputs (BasisState, StatePrepFromGates, or ProductState that is a basis state).
+        """Return True for preparations reducible to one system basis state.
+
+        Accepts :class:`~pennylane.BasisState` unconditionally, and a
+        :class:`~matchcake.operations.state_preparation.ProductState` only when it is
+        unbatched and encodes a computational-basis state. Subclasses of ``ProductState``
+        such as :class:`~matchcake.operations.state_preparation.StatePrepFromGates` are
+        covered by that same check, so a non-basis preparation like
+        :class:`~matchcake.operations.state_preparation.PlusState` falls through to
+        :class:`~matchcake.devices.probability_strategies.ProductStateProbabilityStrategy`
+        instead of reaching a code path that cannot represent it.
+
+        A batched ``ProductState`` is rejected: the explicit sum contracts a single Majorana
+        decomposition of one system state, so a batch of preparations has no single bra/ket
+        pair to sum over. Such inputs fall through to
+        :class:`~matchcake.devices.probability_strategies.ProductStateProbabilityStrategy`.
 
         :param state_prep_op: State preparation operation.
         :type state_prep_op: StatePrepBase
-        :return: True if the state is a computational-basis state.
+        :return: True when this strategy can consume the preparation as one system state.
         :rtype: bool
         """
         from pennylane.ops.qubit.state_preparation import BasisState
 
-        from ...operations.state_preparation import StatePrepFromGates
         from ...operations.state_preparation.product_state import ProductState
 
-        if isinstance(state_prep_op, (BasisState, StatePrepFromGates)):
+        if isinstance(state_prep_op, BasisState):
             return True
         if isinstance(state_prep_op, ProductState):
-            is_basis = state_prep_op.is_basis_state
-            return bool(is_basis) if isinstance(is_basis, bool) else bool(qml.math.all(is_basis))
+            if state_prep_op.batch_size is not None:
+                return False
+            return bool(state_prep_op.is_basis_state)
         return False
 
     def _compute_single(

--- a/src/matchcake/devices/probability_strategies/lookup_table_strategy.py
+++ b/src/matchcake/devices/probability_strategies/lookup_table_strategy.py
@@ -7,7 +7,6 @@ from pennylane.wires import Wires
 
 from ... import utils
 from ...base.lookup_table import NonInteractingFermionicLookupTable
-from ...operations.state_preparation import StatePrepFromGates
 from ...operations.state_preparation.product_state import ProductState
 from .probability_strategy import ProbabilityStrategy
 
@@ -72,16 +71,33 @@ class LookupTableStrategy(ProbabilityStrategy):
         return qml.math.real(utils.pfaffian(obs, sign=False, chunk_size=chunk_size))
 
     def can_execute(self, state_prep_op: StatePrepBase) -> bool:
-        """Return True for basis-state inputs.
+        """Return True for preparations reducible to one system basis state.
+
+        Accepts :class:`~pennylane.BasisState` unconditionally, and a
+        :class:`~matchcake.operations.state_preparation.ProductState` only when it is
+        unbatched and encodes a computational-basis state. Subclasses of ``ProductState``
+        such as :class:`~matchcake.operations.state_preparation.StatePrepFromGates` are
+        covered by that same check, so a non-basis preparation like
+        :class:`~matchcake.operations.state_preparation.PlusState` falls through to
+        :class:`~matchcake.devices.probability_strategies.ProductStateProbabilityStrategy`
+        instead of reaching a code path that cannot represent it.
+
+        A batched ``ProductState`` is rejected: the observable assembled by the lookup table
+        is a ``2 * (k + hamming_weight(system_state))`` square matrix, so preparations with
+        different Hamming weights produce Pfaffian matrices of different sizes that cannot
+        be stacked along a common batch axis. Such inputs fall through to
+        :class:`~matchcake.devices.probability_strategies.ProductStateProbabilityStrategy`,
+        whose matrices are uniformly ``2k x 2k``.
 
         :param state_prep_op: State preparation operation.
         :type state_prep_op: StatePrepBase
-        :return: True when the state encodes a computational-basis state.
+        :return: True when this strategy can consume the preparation as one system state.
         :rtype: bool
         """
-        if isinstance(state_prep_op, (BasisState, StatePrepFromGates)):
+        if isinstance(state_prep_op, BasisState):
             return True
         if isinstance(state_prep_op, ProductState):
-            is_basis = state_prep_op.is_basis_state
-            return bool(is_basis) if isinstance(is_basis, bool) else bool(qml.math.all(is_basis))
+            if state_prep_op.batch_size is not None:
+                return False
+            return bool(state_prep_op.is_basis_state)
         return False

--- a/src/matchcake/devices/probability_strategies/probability_strategy.py
+++ b/src/matchcake/devices/probability_strategies/probability_strategy.py
@@ -9,7 +9,6 @@ from pennylane.typing import TensorLike
 from pennylane.wires import Wires
 from pythonbasictools.multiprocessing_tools import apply_func_multiprocess
 
-from matchcake.operations.state_preparation import StatePrepFromGates
 from matchcake.operations.state_preparation.product_state import ProductState
 
 
@@ -21,17 +20,34 @@ class ProbabilityStrategy(ABC):
     def system_basis_state_from_state_prep_op(cls, state_prep_op: StatePrepBase) -> TensorLike:
         """Extract the computational-basis bit string from a state-preparation op.
 
+        Every :class:`~matchcake.operations.state_preparation.ProductState`, including
+        subclasses such as
+        :class:`~matchcake.operations.state_preparation.StatePrepFromGates`, goes through
+        :meth:`~matchcake.operations.state_preparation.ProductState.basis_state_bits`. This
+        keeps a single definition of basis-ness shared with ``can_execute``, which gates on
+        the matching ``is_basis_state``, so a preparation accepted by ``can_execute`` is
+        always one this method can convert.
+
         :param state_prep_op: The state preparation operation.
         :type state_prep_op: StatePrepBase
         :return: Integer bit array of shape ``(n,)``.
         :rtype: TensorLike
+        :raises ValueError: If ``state_prep_op`` is a batched
+            :class:`~matchcake.operations.state_preparation.ProductState`, which has no single
+            bit string, or if it is not a computational-basis state. Strategies consuming one
+            system state declare this by returning False from ``can_execute``, so the
+            dispatcher routes such preparations elsewhere.
         """
         if isinstance(state_prep_op, BasisState):
             return state_prep_op.parameters[0]
-        elif isinstance(state_prep_op, StatePrepFromGates):
-            return state_prep_op.to_basis_state().parameters[0]
         elif isinstance(state_prep_op, ProductState):
-            return state_prep_op.as_basis_state().parameters[0]
+            if state_prep_op.batch_size is not None:
+                raise ValueError(
+                    f"{cls.__name__} needs a single system basis state, but the given ProductState "
+                    f"is batched (batch_size={state_prep_op.batch_size}). Use a strategy that "
+                    f"supports batched preparations, such as ProductStateProbabilityStrategy."
+                )
+            return state_prep_op.basis_state_bits()
         else:
             raise NotImplementedError(f"{cls.__name__} cannot be used with {type(state_prep_op)}")
 

--- a/tests/test_devices/__init__.py
+++ b/tests/test_devices/__init__.py
@@ -5,6 +5,10 @@ import pennylane as qml
 from pennylane.ops.qubit.observables import BasisStateProjector
 
 from matchcake import MatchgateOperation, NonInteractingFermionicDevice, utils
+from matchcake.devices.probability_strategies import (
+    ProbabilityFuncDispatcher,
+    get_probability_strategy,
+)
 
 _majorana_getters: dict = {}
 
@@ -56,14 +60,20 @@ def init_nif_device(*args, **kwargs) -> NonInteractingFermionicDevice:
         utils.majorana.MajoranaGetter(n_particles, maxsize=kwargs.pop("maxsize", 1024)),
     )
     _majorana_getters[n_particles] = majorana_getter
+    # The device resolves probability strategies through a fixed chain. Tests that need to
+    # exercise one specific strategy pin it by replacing the dispatcher after construction.
+    # The pin is exclusive: the pinned strategy is the only one in the chain, so a state prep
+    # it rejects raises instead of falling back. Pass no prob_strategy to get the full chain.
+    prob_strategy = kwargs.pop("prob_strategy", None)
     nif_device = NonInteractingFermionicDevice(
         wires=wires,
-        prob_strategy=kwargs.pop("prob_strategy", "LookupTable"),
         majorana_getter=kwargs.pop("majorana_getter", majorana_getter),
         n_workers=kwargs.pop("n_workers", 0),
         contraction_strategy=kwargs.pop("contraction_strategy", None),
         **kwargs,
     )
+    if prob_strategy is not None:
+        nif_device.prob_dispatcher = ProbabilityFuncDispatcher([get_probability_strategy(prob_strategy)])
     return nif_device
 
 

--- a/tests/test_devices/test_nif_device/test_batched_product_state_probability.py
+++ b/tests/test_devices/test_nif_device/test_batched_product_state_probability.py
@@ -1,0 +1,203 @@
+import numpy as np
+import pennylane as qml
+import pytest
+import torch
+
+from matchcake import NonInteractingFermionicDevice
+from matchcake.devices.probability_strategies import (
+    CliffordSumStrategy,
+    ExplicitSumStrategy,
+    LookupTableStrategy,
+    ProductStateProbabilityStrategy,
+)
+from matchcake.operations import CompRxRx
+from matchcake.operations.state_preparation import ProductState
+
+from ...configs import (
+    ATOL_MATRIX_COMPARISON,
+    ATOL_SCALAR_COMPARISON,
+    RTOL_MATRIX_COMPARISON,
+    TEST_SEED,
+)
+
+
+class TestBatchedProductStateProbability:
+    @staticmethod
+    def selected_strategy(device):
+        """Return the first strategy in the device chain that accepts the current state prep.
+
+        :param device: Device whose ``prob_dispatcher`` chain is inspected.
+        :type device: NonInteractingFermionicDevice
+        :return: The strategy the dispatcher would route to.
+        :rtype: matchcake.devices.probability_strategies.ProbabilityStrategy
+        """
+        return next(s for s in device.prob_dispatcher.strategies if s.can_execute(device.state_prep_op))
+
+    @staticmethod
+    def apply_circuit(device, prep, theta, n_wires):
+        """Apply a product-state preparation followed by a CompRxRx brick-wall layer.
+
+        :param device: Device to apply the operations on.
+        :type device: NonInteractingFermionicDevice
+        :param prep: State preparation operation.
+        :type prep: ProductState
+        :param theta: Gate angles of shape ``(n_wires - 1, 2)``.
+        :type theta: torch.Tensor
+        :param n_wires: Number of wires.
+        :type n_wires: int
+        :return: None
+        """
+        device.reset()
+        device.apply([prep] + [CompRxRx(theta[w], wires=[w, w + 1]) for w in range(n_wires - 1)])
+
+    @staticmethod
+    def reference_probabilities(inputs, outcomes, theta, n_wires):
+        """Compute reference probabilities on ``default.qubit``, one input state at a time.
+
+        :param inputs: Input basis states of shape ``(n_inputs, n_wires)``.
+        :type inputs: np.ndarray
+        :param outcomes: Queried basis outcomes of shape ``(n_outcomes, n_wires)``.
+        :type outcomes: np.ndarray
+        :param theta: Gate angles of shape ``(n_wires - 1, 2)``.
+        :type theta: torch.Tensor
+        :param n_wires: Number of wires.
+        :type n_wires: int
+        :return: Probabilities of shape ``(n_outcomes, n_inputs)``.
+        :rtype: np.ndarray
+        """
+        qubit_device = qml.device("default.qubit", wires=n_wires)
+
+        @qml.qnode(qubit_device, interface="torch")
+        def circuit(basis_state):
+            qml.BasisState(basis_state, wires=range(n_wires))
+            for w in range(n_wires - 1):
+                CompRxRx(theta[w], wires=[w, w + 1])
+            return qml.probs(wires=range(n_wires))
+
+        outcome_indices = [int("".join(str(int(bit)) for bit in outcome), 2) for outcome in outcomes]
+        columns = [np.asarray(qml.math.detach(circuit(basis_state)))[outcome_indices] for basis_state in inputs]
+        return np.stack(columns, axis=1)
+
+    @pytest.fixture
+    def circuit_data(self):
+        n_wires, n_inputs, n_outcomes = 4, 5, 7
+        rng = np.random.default_rng(TEST_SEED)
+        inputs = (rng.random((n_inputs, n_wires)) < 0.5).astype(int)
+        outcomes = (rng.random((n_outcomes, n_wires)) < 0.5).astype(int)
+        theta = torch.tensor(rng.normal(size=(n_wires - 1, 2)), dtype=torch.float64, requires_grad=True)
+        return n_wires, inputs, outcomes, theta
+
+    def test_default_chain_order(self):
+        device = NonInteractingFermionicDevice(wires=2)
+        assert [type(s) for s in device.prob_dispatcher.strategies] == [
+            LookupTableStrategy,
+            ProductStateProbabilityStrategy,
+            CliffordSumStrategy,
+            ExplicitSumStrategy,
+        ]
+
+    def test_product_state_strategy_precedes_single_state_strategies(self):
+        # Load-bearing invariant: the two trailing strategies only handle a single basis
+        # state, so a batched preparation reaching them would raise. The relative order of
+        # those two is inert because everything they accept is already accepted earlier.
+        device = NonInteractingFermionicDevice(wires=2)
+        strategy_types = [type(s) for s in device.prob_dispatcher.strategies]
+        product_state_index = strategy_types.index(ProductStateProbabilityStrategy)
+        assert product_state_index < strategy_types.index(ExplicitSumStrategy)
+        assert product_state_index < strategy_types.index(CliffordSumStrategy)
+
+    def test_prob_strategy_kwarg_is_ignored(self):
+        # The chain is fixed; a stale ``prob_strategy=`` kwarg must not select anything.
+        device = NonInteractingFermionicDevice(wires=2, prob_strategy="ExplicitSum")
+        assert [type(s) for s in device.prob_dispatcher.strategies] == [
+            LookupTableStrategy,
+            ProductStateProbabilityStrategy,
+            CliffordSumStrategy,
+            ExplicitSumStrategy,
+        ]
+
+    def test_batched_prep_routes_to_product_state_strategy(self, circuit_data):
+        n_wires, inputs, _, theta = circuit_data
+        device = NonInteractingFermionicDevice(wires=n_wires)
+        prep = ProductState.from_basis_state(inputs, wires=range(n_wires))
+        self.apply_circuit(device, prep, theta, n_wires)
+        assert prep.batch_size == len(inputs)
+        assert isinstance(self.selected_strategy(device), ProductStateProbabilityStrategy)
+
+    def test_unbatched_prep_routes_to_lookup_table_strategy(self, circuit_data):
+        n_wires, inputs, _, theta = circuit_data
+        device = NonInteractingFermionicDevice(wires=n_wires)
+        prep = ProductState.from_basis_state(inputs[0], wires=range(n_wires))
+        self.apply_circuit(device, prep, theta, n_wires)
+        assert prep.batch_size is None
+        assert isinstance(self.selected_strategy(device), LookupTableStrategy)
+
+    def test_batched_prep_probabilities_against_qubit_device(self, circuit_data):
+        n_wires, inputs, outcomes, theta = circuit_data
+        device = NonInteractingFermionicDevice(wires=n_wires)
+        prep = ProductState.from_basis_state(inputs, wires=range(n_wires))
+        self.apply_circuit(device, prep, theta, n_wires)
+
+        probabilities = device.get_states_probability(outcomes, device.wires)  # (n_outcomes, n_inputs)
+        expected = self.reference_probabilities(inputs, outcomes, theta, n_wires)
+
+        np.testing.assert_allclose(
+            np.asarray(probabilities.detach()),
+            expected,
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    def test_batched_prep_probabilities_shape(self, circuit_data):
+        n_wires, inputs, outcomes, theta = circuit_data
+        device = NonInteractingFermionicDevice(wires=n_wires)
+        prep = ProductState.from_basis_state(inputs, wires=range(n_wires))
+        self.apply_circuit(device, prep, theta, n_wires)
+        probabilities = device.get_states_probability(outcomes, device.wires)
+        assert tuple(probabilities.shape) == (len(outcomes), len(inputs))
+
+    def test_batched_prep_backward_pass(self, circuit_data):
+        n_wires, inputs, outcomes, theta = circuit_data
+        device = NonInteractingFermionicDevice(wires=n_wires)
+        prep = ProductState.from_basis_state(inputs, wires=range(n_wires))
+        self.apply_circuit(device, prep, theta, n_wires)
+
+        device.get_states_probability(outcomes, device.wires).sum().backward()
+
+        assert theta.grad is not None
+        assert bool(torch.isfinite(theta.grad).all())
+        assert float(torch.linalg.norm(theta.grad)) > ATOL_SCALAR_COMPARISON
+
+    def test_batched_prep_gradient_matches_finite_differences(self):
+        n_wires, n_inputs, n_outcomes = 3, 2, 2
+        rng = np.random.default_rng(TEST_SEED)
+        inputs = np.array([[0, 0, 0], [1, 0, 1]])[:n_inputs]
+        outcomes = np.array([[0, 1, 0], [1, 1, 0]])[:n_outcomes]
+        theta_values = rng.normal(size=(n_wires - 1, 2))
+
+        def total_probability(angles):
+            device = NonInteractingFermionicDevice(wires=n_wires)
+            prep = ProductState.from_basis_state(inputs, wires=range(n_wires))
+            self.apply_circuit(device, prep, angles, n_wires)
+            return device.get_states_probability(outcomes, device.wires).sum()
+
+        theta = torch.tensor(theta_values, dtype=torch.float64, requires_grad=True)
+        total_probability(theta).backward()
+        analytic_grad = np.asarray(theta.grad.detach())
+
+        epsilon = 1e-6
+        numeric_grad = np.zeros_like(theta_values)
+        for index in np.ndindex(theta_values.shape):
+            shifted = theta_values.copy()
+            shifted[index] += epsilon
+            plus = float(total_probability(torch.tensor(shifted, dtype=torch.float64)).detach())
+            shifted[index] -= 2 * epsilon
+            minus = float(total_probability(torch.tensor(shifted, dtype=torch.float64)).detach())
+            numeric_grad[index] = (plus - minus) / (2 * epsilon)
+
+        np.testing.assert_allclose(
+            analytic_grad,
+            numeric_grad,
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )

--- a/tests/test_devices/test_nif_device/test_simultaneous_measurements.py
+++ b/tests/test_devices/test_nif_device/test_simultaneous_measurements.py
@@ -6,6 +6,10 @@ from matchcake import MatchgateOperation, NonInteractingFermionicDevice, utils
 from matchcake import matchgate_parameter_sets as mgp
 from matchcake.circuits import RandomMatchgateOperationsGenerator
 from matchcake.devices.contraction_strategies import contraction_strategy_map
+from matchcake.devices.probability_strategies import (
+    ExplicitSumStrategy,
+    ProbabilityFuncDispatcher,
+)
 from matchcake.operations import (
     CompHH,
     CompRxRx,
@@ -41,7 +45,8 @@ class TestNIFDeviceProbabilities:
         prob = 1.0
 
         initial_binary_state = utils.binary_string_to_vector(initial_binary_string)
-        device = NonInteractingFermionicDevice(wires=wires, prob_strategy="ExplicitSum")
+        device = NonInteractingFermionicDevice(wires=wires)
+        device.prob_dispatcher = ProbabilityFuncDispatcher([ExplicitSumStrategy()])
         operations = [
             qml.BasisState(initial_binary_state, wires=device.wires),
             MatchgateOperation(params, wires=wires),

--- a/tests/test_devices/test_probability_strategies/test_explicit_sum_strategy.py
+++ b/tests/test_devices/test_probability_strategies/test_explicit_sum_strategy.py
@@ -6,6 +6,12 @@ from pennylane.wires import Wires
 from matchcake import utils
 from matchcake.devices.probability_strategies import ExplicitSumStrategy
 from matchcake.operations import SingleParticleTransitionMatrixOperation
+from matchcake.operations.state_preparation import (
+    MinusState,
+    PlusState,
+    ProductState,
+    StatePrepFromGates,
+)
 
 
 class TestExplicitSumStrategy:
@@ -49,3 +55,39 @@ class TestExplicitSumStrategy:
 
     def test_can_execute_non_state_false(self, strategy):
         assert strategy.can_execute(qml.PauliX(0)) is False
+
+    def test_can_execute_unbatched_basis_product_state_true(self, strategy):
+        prep = ProductState.from_basis_state(np.array([1, 0]), wires=[0, 1])
+        assert strategy.can_execute(prep) is True
+
+    def test_can_execute_batched_basis_product_state_false(self, strategy):
+        # The explicit sum contracts the Majorana decomposition of a single system state,
+        # so a batched preparation must fall through rather than raise downstream.
+        prep = ProductState.from_basis_state(np.array([[0, 0], [1, 1]]), wires=[0, 1])
+        assert prep.batch_size == 2
+        assert strategy.can_execute(prep) is False
+
+    def test_can_execute_non_basis_product_state_false(self, strategy):
+        amplitudes = np.full((2, 2), 1.0 / np.sqrt(2), dtype=complex)
+        prep = ProductState(amplitudes, wires=[0, 1])
+        assert strategy.can_execute(prep) is False
+
+    def test_can_execute_basis_state_prep_from_gates_true(self, strategy):
+        prep = StatePrepFromGates(lambda wires: (qml.X(w) for w in wires), wires=[0, 1])
+        assert strategy.can_execute(prep) is True
+
+    @pytest.mark.parametrize("prep_class", [PlusState, MinusState])
+    def test_can_execute_non_basis_state_prep_from_gates_false(self, strategy, prep_class):
+        # ``StatePrepFromGates`` is a ``ProductState`` subclass, so accepting it
+        # unconditionally would send a non-basis preparation into a path that cannot
+        # represent it. It must fall through to ProductStateProbabilityStrategy instead.
+        assert strategy.can_execute(prep_class(wires=[0, 1])) is False
+
+    @pytest.mark.parametrize("prep_class", [PlusState, MinusState])
+    def test_can_execute_false_implies_no_system_basis_state(self, strategy, prep_class):
+        # The load-bearing invariant: ``can_execute`` and the basis-state extraction must
+        # agree, so that a preparation accepted by the former is always convertible.
+        prep = prep_class(wires=[0, 1])
+        assert strategy.can_execute(prep) is False
+        with pytest.raises(ValueError):
+            strategy.system_basis_state_from_state_prep_op(prep)

--- a/tests/test_devices/test_probability_strategies/test_lookup_table_strategy.py
+++ b/tests/test_devices/test_probability_strategies/test_lookup_table_strategy.py
@@ -8,6 +8,12 @@ import pytest
 from matchcake import NonInteractingFermionicDevice
 from matchcake.devices.probability_strategies import LookupTableStrategy
 from matchcake.operations import MatchgateOperation
+from matchcake.operations.state_preparation import (
+    MinusState,
+    PlusState,
+    ProductState,
+    StatePrepFromGates,
+)
 
 from ...configs import ATOL_SCALAR_COMPARISON, set_seed
 
@@ -53,3 +59,40 @@ class TestLookupTableStrategy:
 
     def test_can_execute_non_state_false(self, strategy):
         assert strategy.can_execute(qml.PauliX(0)) is False
+
+    def test_can_execute_unbatched_basis_product_state_true(self, strategy):
+        prep = ProductState.from_basis_state(np.array([1, 0]), wires=[0, 1])
+        assert strategy.can_execute(prep) is True
+
+    def test_can_execute_batched_basis_product_state_false(self, strategy):
+        # The lookup-table observable is 2 * (k + hamming_weight(system_state)) wide, so a
+        # batch of basis states with different Hamming weights cannot be stacked. It must
+        # fall through instead of reaching ``system_basis_state_from_state_prep_op``.
+        prep = ProductState.from_basis_state(np.array([[0, 0], [1, 1]]), wires=[0, 1])
+        assert prep.batch_size == 2
+        assert strategy.can_execute(prep) is False
+
+    def test_can_execute_non_basis_product_state_false(self, strategy):
+        amplitudes = np.full((2, 2), 1.0 / np.sqrt(2), dtype=complex)
+        prep = ProductState(amplitudes, wires=[0, 1])
+        assert strategy.can_execute(prep) is False
+
+    def test_can_execute_basis_state_prep_from_gates_true(self, strategy):
+        prep = StatePrepFromGates(lambda wires: (qml.X(w) for w in wires), wires=[0, 1])
+        assert strategy.can_execute(prep) is True
+
+    @pytest.mark.parametrize("prep_class", [PlusState, MinusState])
+    def test_can_execute_non_basis_state_prep_from_gates_false(self, strategy, prep_class):
+        # ``StatePrepFromGates`` is a ``ProductState`` subclass, so accepting it
+        # unconditionally would send a non-basis preparation into a path that cannot
+        # represent it. It must fall through to ProductStateProbabilityStrategy instead.
+        assert strategy.can_execute(prep_class(wires=[0, 1])) is False
+
+    @pytest.mark.parametrize("prep_class", [PlusState, MinusState])
+    def test_can_execute_false_implies_no_system_basis_state(self, strategy, prep_class):
+        # The load-bearing invariant: ``can_execute`` and the basis-state extraction must
+        # agree, so that a preparation accepted by the former is always convertible.
+        prep = prep_class(wires=[0, 1])
+        assert strategy.can_execute(prep) is False
+        with pytest.raises(ValueError):
+            strategy.system_basis_state_from_state_prep_op(prep)

--- a/tests/test_devices/test_probability_strategies/test_probability_strategy.py
+++ b/tests/test_devices/test_probability_strategies/test_probability_strategy.py
@@ -7,6 +7,12 @@ from matchcake.devices.probability_strategies import (
     LookupTableStrategy,
     ProbabilityStrategy,
 )
+from matchcake.operations.state_preparation import (
+    MinusState,
+    PlusState,
+    ProductState,
+    StatePrepFromGates,
+)
 
 
 class _ConstStrategy(ProbabilityStrategy):
@@ -41,6 +47,41 @@ class TestProbabilityStrategyBase:
         )
         assert tuple(qml.math.shape(out)) == (2,)
         np.testing.assert_array_equal(np.asarray(out), [1, 2])
+
+    def test_system_basis_state_from_unbatched_product_state(self):
+        prep = ProductState.from_basis_state(np.array([1, 0, 1]), wires=[0, 1, 2])
+        bits = ProbabilityStrategy.system_basis_state_from_state_prep_op(prep)
+        np.testing.assert_array_equal(np.asarray(bits), [1, 0, 1])
+
+    def test_system_basis_state_from_batched_product_state_raises(self):
+        prep = ProductState.from_basis_state(np.array([[1, 0], [0, 1]]), wires=[0, 1])
+        with pytest.raises(ValueError, match="needs a single system basis state"):
+            ProbabilityStrategy.system_basis_state_from_state_prep_op(prep)
+
+    def test_system_basis_state_from_unsupported_op_raises(self):
+        with pytest.raises(NotImplementedError):
+            ProbabilityStrategy.system_basis_state_from_state_prep_op(qml.PauliX(0))
+
+    def test_system_basis_state_from_basis_state_prep_from_gates(self):
+        prep = StatePrepFromGates(lambda wires: (qml.X(w) for w in wires), wires=[0, 1, 2])
+        bits = ProbabilityStrategy.system_basis_state_from_state_prep_op(prep)
+        np.testing.assert_array_equal(np.asarray(bits), [1, 1, 1])
+
+    def test_system_basis_state_from_gates_matches_to_basis_state(self):
+        # ``StatePrepFromGates`` is routed through the ``ProductState`` branch, so the bits
+        # it yields must agree with its own gate-counting ``to_basis_state``.
+        prep = StatePrepFromGates(
+            lambda wires: (qml.X(w) for w in wires if w % 2 == 0),
+            wires=[0, 1, 2, 3],
+        )
+        bits = ProbabilityStrategy.system_basis_state_from_state_prep_op(prep)
+        np.testing.assert_array_equal(np.asarray(bits), np.asarray(prep.to_basis_state().parameters[0]))
+
+    @pytest.mark.parametrize("prep_class", [PlusState, MinusState])
+    def test_system_basis_state_from_non_basis_state_prep_from_gates_raises(self, prep_class):
+        prep = prep_class(wires=[0, 1])
+        with pytest.raises(ValueError, match="not a computational-basis state"):
+            ProbabilityStrategy.system_basis_state_from_state_prep_op(prep)
 
     def test_check_required_kwargs_missing_raises(self, strategy):
         with pytest.raises(ValueError, match="Missing required keyword argument"):

--- a/tests/test_operations/test_state_preparation/test_minus_state.py
+++ b/tests/test_operations/test_state_preparation/test_minus_state.py
@@ -4,11 +4,45 @@ import pytest
 from pennylane import X
 
 from matchcake import NonInteractingFermionicDevice
+from matchcake.devices.probability_strategies import ProductStateProbabilityStrategy
+from matchcake.operations import CompRyRy
 from matchcake.operations.state_preparation.minus_state import MinusState
-from tests.configs import ATOL_APPROX_COMPARISON, RTOL_APPROX_COMPARISON
+from tests.configs import (
+    ATOL_APPROX_COMPARISON,
+    ATOL_MATRIX_COMPARISON,
+    RTOL_APPROX_COMPARISON,
+    RTOL_MATRIX_COMPARISON,
+    TEST_SEED,
+)
 
 
 class TestMinusState:
+    @staticmethod
+    def matchgate_angles(num_wires):
+        """Deterministic ``CompRyRy`` angles for a nearest-neighbour brick-wall layer.
+
+        ``CompRyRy`` is used rather than ``CompRxRx`` because it maps the uniform
+        distribution of ``|-...->`` onto a non-uniform one, so the comparison against
+        ``default.qubit`` is sensitive to an incorrect probability path.
+
+        :param num_wires: Number of wires.
+        :type num_wires: int
+        :return: Angles of shape ``(num_wires - 1, 2)``.
+        :rtype: np.ndarray
+        """
+        return np.random.default_rng(TEST_SEED).normal(size=(num_wires - 1, 2))
+
+    @staticmethod
+    def selected_strategy(device):
+        """Return the strategy the device's dispatcher routes the current preparation to.
+
+        :param device: Device whose ``prob_dispatcher`` chain is inspected.
+        :type device: NonInteractingFermionicDevice
+        :return: The selected probability strategy.
+        :rtype: matchcake.devices.probability_strategies.ProbabilityStrategy
+        """
+        return next(s for s in device.prob_dispatcher.strategies if s.can_execute(device.state_prep_op))
+
     @pytest.mark.parametrize("num_wires", [2, 3, 4, 5])
     def test_state_vector(self, num_wires):
         qubit_dev = qml.device("lightning.qubit", wires=num_wires)
@@ -43,6 +77,62 @@ class TestMinusState:
             atol=ATOL_APPROX_COMPARISON,
             rtol=RTOL_APPROX_COMPARISON,
         )
+
+    @pytest.mark.parametrize("num_wires", [2, 3, 4])
+    def test_probs_against_qubit_device(self, num_wires):
+        nif_dev = NonInteractingFermionicDevice(wires=num_wires)
+        qubit_dev = qml.device("default.qubit", wires=num_wires)
+
+        def circuit():
+            MinusState(wires=range(num_wires))
+            return qml.probs(wires=range(num_wires))
+
+        actual_value = qml.math.detach(qml.QNode(circuit, nif_dev)())
+        expected_value = qml.math.detach(qml.QNode(circuit, qubit_dev)())
+
+        np.testing.assert_allclose(
+            np.asarray(actual_value),
+            np.asarray(expected_value),
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    @pytest.mark.parametrize("num_wires", [2, 3, 4])
+    def test_probs_with_matchgates_against_qubit_device(self, num_wires):
+        nif_dev = NonInteractingFermionicDevice(wires=num_wires)
+        qubit_dev = qml.device("default.qubit", wires=num_wires)
+        angles = self.matchgate_angles(num_wires)
+
+        def circuit():
+            MinusState(wires=range(num_wires))
+            for wire in range(num_wires - 1):
+                CompRyRy(angles[wire], wires=[wire, wire + 1])
+            return qml.probs(wires=range(num_wires))
+
+        actual_value = np.asarray(qml.math.detach(qml.QNode(circuit, nif_dev)()))
+        expected_value = np.asarray(qml.math.detach(qml.QNode(circuit, qubit_dev)()))
+
+        # Guard against a vacuous comparison: the layer must break the uniformity of |-...->.
+        assert expected_value.max() - expected_value.min() > ATOL_APPROX_COMPARISON
+        np.testing.assert_allclose(
+            actual_value,
+            expected_value,
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    def test_probs_routes_to_product_state_strategy(self):
+        # |-> is not a computational-basis state, so the single-basis-state strategies must
+        # decline it and let it fall through to the covariance-matrix strategy.
+        nif_dev = NonInteractingFermionicDevice(wires=2)
+        nif_dev.apply([MinusState(wires=[0, 1])])
+        assert isinstance(self.selected_strategy(nif_dev), ProductStateProbabilityStrategy)
+
+    def test_probs_with_matchgates_routes_to_product_state_strategy(self):
+        nif_dev = NonInteractingFermionicDevice(wires=2)
+        angles = self.matchgate_angles(2)
+        nif_dev.apply([MinusState(wires=[0, 1]), CompRyRy(angles[0], wires=[0, 1])])
+        assert isinstance(self.selected_strategy(nif_dev), ProductStateProbabilityStrategy)
 
     def test_label(self):
         op = MinusState(wires=[0, 1])

--- a/tests/test_operations/test_state_preparation/test_plus_state.py
+++ b/tests/test_operations/test_state_preparation/test_plus_state.py
@@ -4,11 +4,45 @@ import pytest
 from pennylane import X
 
 from matchcake import NonInteractingFermionicDevice
+from matchcake.devices.probability_strategies import ProductStateProbabilityStrategy
+from matchcake.operations import CompRyRy
 from matchcake.operations.state_preparation.plus_state import PlusState
-from tests.configs import ATOL_APPROX_COMPARISON, RTOL_APPROX_COMPARISON
+from tests.configs import (
+    ATOL_APPROX_COMPARISON,
+    ATOL_MATRIX_COMPARISON,
+    RTOL_APPROX_COMPARISON,
+    RTOL_MATRIX_COMPARISON,
+    TEST_SEED,
+)
 
 
 class TestPlusState:
+    @staticmethod
+    def matchgate_angles(num_wires):
+        """Deterministic ``CompRyRy`` angles for a nearest-neighbour brick-wall layer.
+
+        ``CompRyRy`` is used rather than ``CompRxRx`` because it maps the uniform
+        distribution of ``|+...+>`` onto a non-uniform one, so the comparison against
+        ``default.qubit`` is sensitive to an incorrect probability path.
+
+        :param num_wires: Number of wires.
+        :type num_wires: int
+        :return: Angles of shape ``(num_wires - 1, 2)``.
+        :rtype: np.ndarray
+        """
+        return np.random.default_rng(TEST_SEED).normal(size=(num_wires - 1, 2))
+
+    @staticmethod
+    def selected_strategy(device):
+        """Return the strategy the device's dispatcher routes the current preparation to.
+
+        :param device: Device whose ``prob_dispatcher`` chain is inspected.
+        :type device: NonInteractingFermionicDevice
+        :return: The selected probability strategy.
+        :rtype: matchcake.devices.probability_strategies.ProbabilityStrategy
+        """
+        return next(s for s in device.prob_dispatcher.strategies if s.can_execute(device.state_prep_op))
+
     @pytest.mark.parametrize("num_wires", [2, 3, 4, 5])
     def test_state_vector(self, num_wires):
         qubit_dev = qml.device("lightning.qubit", wires=num_wires)
@@ -42,6 +76,62 @@ class TestPlusState:
             atol=ATOL_APPROX_COMPARISON,
             rtol=RTOL_APPROX_COMPARISON,
         )
+
+    @pytest.mark.parametrize("num_wires", [2, 3, 4])
+    def test_probs_against_qubit_device(self, num_wires):
+        nif_dev = NonInteractingFermionicDevice(wires=num_wires)
+        qubit_dev = qml.device("default.qubit", wires=num_wires)
+
+        def circuit():
+            PlusState(wires=range(num_wires))
+            return qml.probs(wires=range(num_wires))
+
+        actual_value = qml.math.detach(qml.QNode(circuit, nif_dev)())
+        expected_value = qml.math.detach(qml.QNode(circuit, qubit_dev)())
+
+        np.testing.assert_allclose(
+            np.asarray(actual_value),
+            np.asarray(expected_value),
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    @pytest.mark.parametrize("num_wires", [2, 3, 4])
+    def test_probs_with_matchgates_against_qubit_device(self, num_wires):
+        nif_dev = NonInteractingFermionicDevice(wires=num_wires)
+        qubit_dev = qml.device("default.qubit", wires=num_wires)
+        angles = self.matchgate_angles(num_wires)
+
+        def circuit():
+            PlusState(wires=range(num_wires))
+            for wire in range(num_wires - 1):
+                CompRyRy(angles[wire], wires=[wire, wire + 1])
+            return qml.probs(wires=range(num_wires))
+
+        actual_value = np.asarray(qml.math.detach(qml.QNode(circuit, nif_dev)()))
+        expected_value = np.asarray(qml.math.detach(qml.QNode(circuit, qubit_dev)()))
+
+        # Guard against a vacuous comparison: the layer must break the uniformity of |+...+>.
+        assert expected_value.max() - expected_value.min() > ATOL_APPROX_COMPARISON
+        np.testing.assert_allclose(
+            actual_value,
+            expected_value,
+            atol=ATOL_MATRIX_COMPARISON,
+            rtol=RTOL_MATRIX_COMPARISON,
+        )
+
+    def test_probs_routes_to_product_state_strategy(self):
+        # |+> is not a computational-basis state, so the single-basis-state strategies must
+        # decline it and let it fall through to the covariance-matrix strategy.
+        nif_dev = NonInteractingFermionicDevice(wires=2)
+        nif_dev.apply([PlusState(wires=[0, 1])])
+        assert isinstance(self.selected_strategy(nif_dev), ProductStateProbabilityStrategy)
+
+    def test_probs_with_matchgates_routes_to_product_state_strategy(self):
+        nif_dev = NonInteractingFermionicDevice(wires=2)
+        angles = self.matchgate_angles(2)
+        nif_dev.apply([PlusState(wires=[0, 1]), CompRyRy(angles[0], wires=[0, 1])])
+        assert isinstance(self.selected_strategy(nif_dev), ProductStateProbabilityStrategy)
 
     def test_label(self):
         op = PlusState(wires=[0, 1])


### PR DESCRIPTION
# Description

This pull request refactors how probability strategies are selected and dispatched in the `NonInteractingFermionicDevice`, moving from a user-selected strategy via a keyword argument to a fixed, ordered dispatcher chain that routes based on input compatibility. It also improves the logic for determining which probability strategies can handle various state preparations, especially for batched and unbatched product states, and adds comprehensive tests for these behaviors.

**Probability strategy dispatch and selection:**

* The device now uses a fixed, ordered chain of probability strategies via `prob_dispatcher`, removing the `prob_strategy` keyword argument as a user selection mechanism. Users who want to pin a specific strategy must now replace the dispatcher after device construction. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L94-L96) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L237-R241) [[3]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L140) [[4]](diffhunk://#diff-c91754d93bbdf012e05e0c3fabb2a4f30d0fa29cfe616f66b1ea3ce2361e046bR63-R76)
* The dispatcher’s default order is: `LookupTableStrategy`, `ProductStateProbabilityStrategy`, `CliffordSumStrategy`, then `ExplicitSumStrategy`. This ensures batched product states are handled by the correct strategy, avoiding errors in strategies that only support single states. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L237-R241) [[2]](diffhunk://#diff-781c340f74dc153588b64c72bba4b38c45c857d0e5ba3af3518abdca789b3683R1-R203)

**Strategy compatibility improvements:**

* The `can_execute` methods for `LookupTableStrategy` and `ExplicitSumStrategy` are rewritten to precisely accept only preparations reducible to a single, unbatched system basis state, and to reject batched product states, ensuring proper routing in the dispatcher. [[1]](diffhunk://#diff-b5568555855d254def5f3781bf8cd7e29dfcf3b0635f84ebd4ad729368bdab75L39-R69) [[2]](diffhunk://#diff-468caba29ab8633456e0e36129838e4ee00441aedcdb62043ccb86f26163fc1eL75-R102)
* The logic for extracting basis states from state preparation operations is centralized and clarified, with explicit error handling for batched or incompatible preparations.

**Testing enhancements:**

* Adds a new test suite (`test_batched_product_state_probability.py`) that verifies the dispatcher routes batched and unbatched product states to the correct strategies, checks probability outputs and gradients, and ensures the dispatcher chain is in the intended order.
* Updates test utilities and imports to support the new dispatcher-based selection mechanism. [[1]](diffhunk://#diff-c91754d93bbdf012e05e0c3fabb2a4f30d0fa29cfe616f66b1ea3ce2361e046bR8-R11) [[2]](diffhunk://#diff-4f23f2b1510d10387d730df05fdbe6b7c0e55e545b999fba335c1cec5ffa5397R9-R12)

These changes collectively improve the robustness, maintainability, and correctness of probability computation in the device, especially for batched product states.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
