### PR TITLE
Make kwargs explicit

### DIFF
--- a/src/matchcake/devices/nif_device.py
+++ b/src/matchcake/devices/nif_device.py
@@ -90,27 +90,43 @@ class NonInteractingFermionicDevice(qml.devices.Device):
 
     :param wires: The number of wires of the device
     :type wires: Union[int, Wires, List[int]]
+    :param shots: The number of shots used by the device. Defaults to ``None`` (analytic mode).
+    :type shots: Optional[int]
+    :param r_dtype: The real floating-point dtype used for real-valued tensors. Accepts a ``torch.dtype``, a
+        numpy scalar type (e.g. ``np.float32``) or a Python builtin (e.g. ``float``). Defaults to the class
+        attribute :attr:`R_DTYPE` (``torch.float64``).
+    :type r_dtype: Optional[Union[torch.dtype, type]]
+    :param c_dtype: The complex dtype used for complex-valued tensors throughout the pipeline (single-particle
+        transition matrices, lookup table, observables). Accepts a ``torch.dtype``, a numpy scalar type
+        (e.g. ``np.complex64``) or a Python builtin (e.g. ``complex``). Defaults to the class attribute
+        :attr:`C_DTYPE` (``torch.complex128``) to preserve maximum precision. Set to e.g. ``torch.complex64``
+        to reduce memory usage and computation cost.
+    :type c_dtype: Optional[Union[torch.dtype, type]]
+    :param pfaffian_chunk_size: Max number of matrices reduced per batched Pfaffian call, forwarded to
+        :func:`matchcake.utils.pfaffian` to bound memory. Defaults to ``None`` (no chunking).
+    :type pfaffian_chunk_size: Optional[int]
+    :param show_progress: Whether to display progress bars while applying operations and computing
+        probabilities. Defaults to ``None``, meaning progress is shown only when an external progress bar is
+        supplied through the ``p_bar`` keyword argument.
+    :type show_progress: Optional[bool]
 
     :kwargs: Additional keyword arguments
 
     :keyword majorana_getter: The Majorana getter to use. Defaults to a new instance of MajoranaGetter.
     :type majorana_getter: MajoranaGetter
-    :keyword contraction_method: The contraction method to use. Can be either None or "neighbours".
-        Defaults to None.
-    :type contraction_method: Optional[str]
-    :keyword n_workers: The number of workers to use for multiprocessing. Defaults to 0.
-    :type n_workers: int
-    :keyword star_state_finding_strategy: The strategy to find the star state.
+    :keyword contraction_strategy: The contraction strategy used to merge consecutive operations. Accepts a
+        strategy name or instance, or ``None`` to disable contraction. Defaults to
+        :attr:`DEFAULT_CONTRACTION_METHOD`.
+    :type contraction_strategy: Optional[Union[str, ContractionStrategy]]
+    :keyword sampling_strategy: The strategy used to draw samples in finite-shot mode. Defaults to
+        :attr:`DEFAULT_SAMPLING_STRATEGY`.
+    :type sampling_strategy: Union[str, SamplingStrategy]
+    :keyword star_state_finding_strategy: The strategy to find the star state. Defaults to
+        :attr:`DEFAULT_STAR_STATE_FINDING_STRATEGY`.
     :type star_state_finding_strategy: Union[str, StarStateFindingStrategy]
-    :keyword r_dtype: The real floating-point dtype used for real-valued tensors. Defaults to ``torch.float64``.
-    :type r_dtype: torch.dtype
-    :keyword c_dtype: The complex dtype used for complex-valued tensors throughout the pipeline (single-particle
-        transition matrices, lookup table, observables). Defaults to ``torch.complex128`` to preserve maximum
-        precision. Set to e.g. ``torch.complex64`` to reduce memory usage and computation cost.
-    :type c_dtype: torch.dtype
-    :keyword pfaffian_chunk_size: Max number of matrices reduced per batched Pfaffian call, forwarded to
-        :func:`matchcake.utils.pfaffian` to bound memory. Defaults to ``None`` (no chunking).
-    :type pfaffian_chunk_size: Optional[int]
+    :keyword p_bar: An external progress bar reused by the device instead of creating its own. Defaults to
+        ``None``. Supplying one turns ``show_progress`` on unless ``show_progress`` is given a boolean value.
+    :type p_bar: Optional[tqdm.tqdm]
 
     :Note: This device is a simulator for non-interacting fermions. It is based on the ``default.qubit`` device.
     :Note: This device supports batch execution.
@@ -203,6 +219,10 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         wires: Optional[Union[int, Wires, List[int]]] = None,
         *,
         shots: Optional[int] = None,
+        r_dtype: Optional[Union[torch.dtype, type]] = None,
+        c_dtype: Optional[Union[torch.dtype, type]] = None,
+        pfaffian_chunk_size: Optional[int] = None,
+        show_progress: Optional[bool] = None,
         **kwargs,
     ):
         if wires is not None:
@@ -215,8 +235,8 @@ class NonInteractingFermionicDevice(qml.devices.Device):
         self._debugger = kwargs.get("debugger", None)
         self._init_kwargs = kwargs
 
-        self.R_DTYPE = torch_utils.get_torch_dtype(kwargs.get("r_dtype"), type(self).R_DTYPE)
-        self.C_DTYPE = torch_utils.get_torch_dtype(kwargs.get("c_dtype"), type(self).C_DTYPE)
+        self.R_DTYPE = torch_utils.get_torch_dtype(r_dtype, type(self).R_DTYPE)
+        self.C_DTYPE = torch_utils.get_torch_dtype(c_dtype, type(self).C_DTYPE)
         self._c_dtype_name = str(self.C_DTYPE).rsplit(".", 1)[-1]
         self._r_dtype_name = str(self.R_DTYPE).rsplit(".", 1)[-1]
 
@@ -250,9 +270,9 @@ class NonInteractingFermionicDevice(qml.devices.Device):
                 self.DEFAULT_STAR_STATE_FINDING_STRATEGY,
             )
         )
-        self.pfaffian_chunk_size: Optional[int] = kwargs.get("pfaffian_chunk_size", None)
+        self.pfaffian_chunk_size: Optional[int] = pfaffian_chunk_size
         self.p_bar: Optional[tqdm.tqdm] = kwargs.get("p_bar", None)
-        self.show_progress = kwargs.get("show_progress", self.p_bar is not None)
+        self.show_progress: bool = (self.p_bar is not None) if show_progress is None else show_progress
         self.apply_metadata: defaultdict = defaultdict()
         self.clifford_expval_strategy = CliffordExpvalStrategy()
         self.expval_from_probabilities_strategy = ExpvalFromProbabilitiesStrategy()

--- a/tests/test_devices/test_nif_device/test_nif_device_dtype.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_dtype.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import pennylane as qml
 import pytest
@@ -56,6 +58,18 @@ class TestNIFDeviceDtype:
         device = NonInteractingFermionicDevice(wires=2, c_dtype=np.complex64, r_dtype=np.float32)
         assert device.C_DTYPE == torch.complex64
         assert device.R_DTYPE == torch.float32
+
+    @pytest.mark.parametrize("dtype_name", ["r_dtype", "c_dtype"])
+    def test_dtype_is_an_explicit_keyword_only_parameter(self, dtype_name):
+        parameters = inspect.signature(NonInteractingFermionicDevice.__init__).parameters
+        assert dtype_name in parameters, f"{dtype_name} must be explicit in the signature, not hidden in **kwargs."
+        assert parameters[dtype_name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameters[dtype_name].default is None
+
+    @pytest.mark.parametrize("dtype_name, dtype", [("r_dtype", torch.float32), ("c_dtype", torch.complex64)])
+    def test_dtype_is_not_captured_by_init_kwargs(self, dtype_name, dtype):
+        device = NonInteractingFermionicDevice(wires=2, **{dtype_name: dtype})
+        assert dtype_name not in device._init_kwargs
 
     @pytest.mark.parametrize("r_dtype, real_name, complex_name", _DTYPE_CASES)
     def test_global_sptm_is_real_and_transition_matrix_is_complex(self, r_dtype, real_name, complex_name):

--- a/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
+++ b/tests/test_devices/test_nif_device/test_nif_device_methods_and_properties.py
@@ -1,3 +1,5 @@
+import inspect
+
 import numpy as np
 import pennylane as qml
 import pytest
@@ -188,6 +190,48 @@ class TestNIFDeviceMethodsAndProperties:
         bar = dev.initialize_p_bar(total=5, desc="test")
         assert isinstance(bar, tqdm.tqdm)
         bar.close()
+
+    @pytest.mark.parametrize("parameter_name", ["pfaffian_chunk_size", "show_progress"])
+    def test_parameter_is_explicit_keyword_only(self, parameter_name):
+        parameters = inspect.signature(NonInteractingFermionicDevice.__init__).parameters
+        assert parameter_name in parameters, f"{parameter_name} must be explicit, not hidden in **kwargs."
+        assert parameters[parameter_name].kind is inspect.Parameter.KEYWORD_ONLY
+        assert parameters[parameter_name].default is None
+
+    @pytest.mark.parametrize("parameter_name, value", [("pfaffian_chunk_size", 4), ("show_progress", True)])
+    def test_parameter_is_not_captured_by_init_kwargs(self, parameter_name, value):
+        dev = NonInteractingFermionicDevice(wires=2, **{parameter_name: value})
+        assert parameter_name not in dev._init_kwargs
+
+    @pytest.mark.parametrize("chunk_size", [None, 1, 8])
+    def test_pfaffian_chunk_size_is_stored_verbatim(self, chunk_size):
+        dev = NonInteractingFermionicDevice(wires=2, pfaffian_chunk_size=chunk_size)
+        assert dev.pfaffian_chunk_size == chunk_size
+
+    def test_show_progress_defaults_to_false_without_p_bar(self):
+        dev = NonInteractingFermionicDevice(wires=2)
+        assert dev.show_progress is False
+
+    def test_show_progress_defaults_to_true_with_p_bar(self):
+        bar = tqdm.tqdm(total=5, disable=True)
+        dev = NonInteractingFermionicDevice(wires=2, p_bar=bar)
+        assert dev.show_progress is True
+        bar.close()
+
+    @pytest.mark.parametrize("show_progress", [True, False])
+    def test_show_progress_explicit_value_overrides_p_bar_default(self, show_progress):
+        bar = tqdm.tqdm(total=5, disable=True)
+        dev = NonInteractingFermionicDevice(wires=2, p_bar=bar, show_progress=show_progress)
+        assert dev.show_progress is show_progress
+        bar.close()
+
+    @pytest.mark.parametrize("p_bar_given, expected", [(False, False), (True, True)])
+    def test_explicit_none_show_progress_resolves_to_the_p_bar_default(self, p_bar_given, expected):
+        bar = tqdm.tqdm(total=5, disable=True) if p_bar_given else None
+        dev = NonInteractingFermionicDevice(wires=2, p_bar=bar, show_progress=None)
+        assert dev.show_progress is expected
+        if bar is not None:
+            bar.close()
 
     def test_update_p_bar_with_active_bar(self):
         dev = NonInteractingFermionicDevice(wires=2, show_progress=True)


### PR DESCRIPTION
# Description

This pull request refactors the initialization and parameter handling of the `NonInteractingFermionicDevice` class to make several device configuration options explicit keyword-only parameters, rather than being passed via `**kwargs`. It also updates the device's docstring to reflect these changes and adds comprehensive tests to ensure correct parameter handling and defaults.

**Device API improvements:**

* Made `r_dtype`, `c_dtype`, `pfaffian_chunk_size`, and `show_progress` explicit keyword-only parameters in the `NonInteractingFermionicDevice.__init__` signature, instead of being passed via `**kwargs`. This clarifies the API and improves type safety. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109R222-R225) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L218-R239) [[3]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L253-R275)
* Updated the device's docstring to document the new explicit parameters and clarify their types and default behaviors.

**Parameter handling and logic:**

* Changed how `show_progress` is determined: it now defaults to `True` if a `p_bar` is supplied and `show_progress` is not explicitly set, otherwise `False`.
* Ensured that the explicit parameters (`r_dtype`, `c_dtype`, `pfaffian_chunk_size`, `show_progress`) are not captured in `self._init_kwargs`, keeping the device's internal state clean. [[1]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L218-R239) [[2]](diffhunk://#diff-d3d98a3f02c9d992f279a2e4a8ce9be54398925fd43d2bad3165214a35e1c109L253-R275)

**Testing improvements:**

* Added tests to verify that the new parameters are explicit keyword-only arguments, are not stored in `_init_kwargs`, and that their defaulting logic works as intended. [[1]](diffhunk://#diff-02c6ccad154f3cae0ee7d94a2795cc1f09b47800cf3252acf3894e32e34f784fR1-R2) [[2]](diffhunk://#diff-02c6ccad154f3cae0ee7d94a2795cc1f09b47800cf3252acf3894e32e34f784fR62-R73) [[3]](diffhunk://#diff-6fce237ad7ba216d57a7254539f91ce2c7c487464e395119bc2a448abb80ef3eR1-R2) [[4]](diffhunk://#diff-6fce237ad7ba216d57a7254539f91ce2c7c487464e395119bc2a448abb80ef3eR194-R235)

These changes make the device's API more explicit, robust, and user-friendly, while improving test coverage and maintainability.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
