### PR TITLE
Pennylane dev registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ homepage = "https://github.com/MatchCake/MatchCake"
 Documentation = "https://github.com/MatchCake/MatchCake"
 Source = "https://MatchCake.github.io/MatchCake"
 
+[project.entry-points."pennylane.plugins"]
+"nif.qubit" = "matchcake.devices.nif_device:NonInteractingFermionicDevice"
+
 [tool.pytest.ini_options]
 pythonpath = [
     ".", "src",

--- a/tests/test_devices/test_device_registration.py
+++ b/tests/test_devices/test_device_registration.py
@@ -1,0 +1,68 @@
+from importlib import metadata
+
+import numpy as np
+import pennylane as qml
+import pytest
+
+from matchcake.devices import NonInteractingFermionicDevice
+from matchcake.operations import fSWAP
+
+from ..configs import ATOL_SCALAR_COMPARISON, RTOL_SCALAR_COMPARISON, TEST_SEED, set_seed
+
+ENTRY_POINT_GROUP = "pennylane.plugins"
+
+
+class TestDeviceRegistration:
+    @classmethod
+    def setup_class(cls) -> None:
+        set_seed(TEST_SEED)
+
+    @staticmethod
+    def _entry_points() -> dict[str, str]:
+        entries = metadata.entry_points(group=ENTRY_POINT_GROUP)
+        return {entry.name: entry.value for entry in entries}
+
+    @pytest.mark.parametrize(
+        "short_name,expected_class",
+        [
+            ("nif.qubit", NonInteractingFermionicDevice),
+        ],
+    )
+    def test_entry_point_is_declared(self, short_name: str, expected_class: type) -> None:
+        entry_points = self._entry_points()
+        assert short_name in entry_points
+        module_path, _, attribute = entry_points[short_name].partition(":")
+        assert attribute == expected_class.__name__
+        assert expected_class.__module__ == module_path
+
+    @pytest.mark.parametrize(
+        "short_name,expected_class",
+        [
+            ("nif.qubit", NonInteractingFermionicDevice),
+        ],
+    )
+    def test_device_resolves_by_name(self, short_name: str, expected_class: type) -> None:
+        device = qml.device(short_name, wires=2)
+        assert isinstance(device, expected_class)
+
+    @pytest.mark.parametrize("short_name", ["nif.qubit"])
+    def test_registered_name_matches_class_attribute(self, short_name: str) -> None:
+        device = qml.device(short_name, wires=2)
+        assert device.name == short_name
+
+    def test_resolved_device_executes_circuit(self) -> None:
+        device = qml.device("nif.qubit", wires=2)
+
+        @qml.qnode(device)
+        def circuit() -> qml.measurements.ExpectationMP:
+            qml.BasisState(np.array([0, 0]), wires=[0, 1])
+            fSWAP(wires=[0, 1])
+            return qml.expval(qml.PauliZ(0))
+
+        result = circuit()
+        np.testing.assert_allclose(
+            float(result),
+            1.0,
+            atol=ATOL_SCALAR_COMPARISON,
+            rtol=RTOL_SCALAR_COMPARISON,
+        )


### PR DESCRIPTION
# Description

This pull request registers the `NonInteractingFermionicDevice` as a PennyLane plugin under the name `nif.qubit` and adds comprehensive tests to ensure the device is correctly discoverable and usable via the PennyLane entry point system.

**Device registration:**

* Added a `[project.entry-points."pennylane.plugins"]` section to `pyproject.toml`, registering `"nif.qubit"` to point to `matchcake.devices.nif_device:NonInteractingFermionicDevice`.

**Testing:**

* Introduced `tests/test_devices/test_device_registration.py` to verify:
  - The entry point is declared and resolves to the correct class.
  - The device can be instantiated by short name.
  - The device's registered name matches its class attribute.
  - The device executes a simple circuit correctly.

------------------------------------------------------------------------------------------------------------

# Checklist

Please complete the following checklist when submitting a PR. The PR will not be reviewed until all items are checked.

- [x] All new features include a unit test.
      Make sure that the tests passed and the coverage is
      sufficient by running
      `uv run pytest --session-timeout=600`.
- [x] All new functions and code are clearly documented.
- [x] The code passes all pre-commit hooks.
      You can do this by running `uvx pre-commit run --all-files`.
- [x] The code is type-checked using Mypy.
      You can do this by running `uv run mypy src tests`.
