### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'MatchCake: A Python Simulator for Non-Interacting Fermionic Quantum Circuits with Machine Learning
+  Applications'
+type: software
+authors:
+- given-names: Jérémie
+  family-names: Gince
+  orcid: https://orcid.org/0009-0002-7179-375X
+repository-code: https://github.com/MatchCake/MatchCake
+license: Apache-2.0


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and tools can pick up machine-readable citation metadata.

Author names and ORCIDs are taken from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Please check the given-name/family-name split is right for each author, since I derived it from the single `name` field in the paper.