### PR TITLE
Add available DOIs to two paper.bib entries

### DIFF
--- a/joss/paper.bib
+++ b/joss/paper.bib
@@ -126,7 +126,8 @@
   number={19},
   pages={195302},
   year={2025},
-  publisher={IOP Publishing}
+  publisher={IOP Publishing},
+  doi={10.1088/1751-8121/adcd15}
 }
 
 
@@ -191,7 +192,8 @@
   volume={3},
   number={29},
   pages={819},
-  year={2018}
+  year={2018},
+  doi={10.21105/joss.00819}
 }
 
 @article{nielsen2005fermionic,


### PR DESCRIPTION
Closes #158.

Two `joss/paper.bib` entries had no `doi` field despite the DOI being
registered on Crossref. Here are the DOIs:

| Entry | DOI |
| --- | --- |
| `projansky2025gaussianity` | `10.1088/1751-8121/adcd15` |
| `gray2018quimb` | `10.21105/joss.00819` |